### PR TITLE
Add UTM zone to frame_id; added reverse_utm_odometry_node

### DIFF
--- a/gps_common/CMakeLists.txt
+++ b/gps_common/CMakeLists.txt
@@ -50,10 +50,23 @@ catkin_package(
 ###########
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${catkin_INCLUDE_DIRS})
+
 add_executable(${PROJECT_NAME}/utm_odometry_node src/utm_odometry_node.cpp)
+add_executable(${PROJECT_NAME}/reverse_utm_odometry_node src/reverse_utm_odometry_node.cpp)
+
 set_target_properties(${PROJECT_NAME}/utm_odometry_node PROPERTIES OUTPUT_NAME "utm_odometry_node")
 target_link_libraries(${PROJECT_NAME}/utm_odometry_node ${catkin_LIBRARIES})
+
+set_target_properties(${PROJECT_NAME}/reverse_utm_odometry_node PROPERTIES OUTPUT_NAME "reverse_utm_odometry_node")
+target_link_libraries(${PROJECT_NAME}/reverse_utm_odometry_node ${catkin_LIBRARIES})
+
 add_dependencies(${PROJECT_NAME}/utm_odometry_node
+  ${PROJECT_NAME}_generate_messages_cpp 
+  ${catkin_EXPORTED_TARGETS} 
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+)
+
+add_dependencies(${PROJECT_NAME}/reverse_utm_odometry_node
   ${PROJECT_NAME}_generate_messages_cpp 
   ${catkin_EXPORTED_TARGETS} 
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
@@ -63,7 +76,9 @@ add_dependencies(${PROJECT_NAME}/utm_odometry_node
 ## Install ##
 #############
 
-install(TARGETS ${PROJECT_NAME}/utm_odometry_node
+install(TARGETS
+  ${PROJECT_NAME}/utm_odometry_node
+  ${PROJECT_NAME}/reverse_utm_odometry_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/gps_common/CMakeLists.txt
+++ b/gps_common/CMakeLists.txt
@@ -52,13 +52,13 @@ catkin_package(
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${catkin_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME}/utm_odometry_node src/utm_odometry_node.cpp)
-add_executable(${PROJECT_NAME}/reverse_utm_odometry_node src/reverse_utm_odometry_node.cpp)
+add_executable(${PROJECT_NAME}/utm_odometry_to_navsatfix_node src/utm_odometry_to_navsatfix_node.cpp)
 
 set_target_properties(${PROJECT_NAME}/utm_odometry_node PROPERTIES OUTPUT_NAME "utm_odometry_node")
 target_link_libraries(${PROJECT_NAME}/utm_odometry_node ${catkin_LIBRARIES})
 
-set_target_properties(${PROJECT_NAME}/reverse_utm_odometry_node PROPERTIES OUTPUT_NAME "reverse_utm_odometry_node")
-target_link_libraries(${PROJECT_NAME}/reverse_utm_odometry_node ${catkin_LIBRARIES})
+set_target_properties(${PROJECT_NAME}/utm_odometry_to_navsatfix_node PROPERTIES OUTPUT_NAME "utm_odometry_to_navsatfix_node")
+target_link_libraries(${PROJECT_NAME}/utm_odometry_to_navsatfix_node ${catkin_LIBRARIES})
 
 add_dependencies(${PROJECT_NAME}/utm_odometry_node
   ${PROJECT_NAME}_generate_messages_cpp 
@@ -66,7 +66,7 @@ add_dependencies(${PROJECT_NAME}/utm_odometry_node
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
 )
 
-add_dependencies(${PROJECT_NAME}/reverse_utm_odometry_node
+add_dependencies(${PROJECT_NAME}/utm_odometry_to_navsatfix_node
   ${PROJECT_NAME}_generate_messages_cpp 
   ${catkin_EXPORTED_TARGETS} 
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
@@ -78,7 +78,7 @@ add_dependencies(${PROJECT_NAME}/reverse_utm_odometry_node
 
 install(TARGETS
   ${PROJECT_NAME}/utm_odometry_node
-  ${PROJECT_NAME}/reverse_utm_odometry_node
+  ${PROJECT_NAME}/utm_odometry_to_navsatfix_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/gps_common/src/reverse_utm_odometry_node.cpp
+++ b/gps_common/src/reverse_utm_odometry_node.cpp
@@ -1,0 +1,69 @@
+/*
+ * Translates nav_msgs/Odometry into sensor_msgs/NavSat{Fix,Status}
+ */
+
+#include <ros/ros.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <sensor_msgs/NavSatStatus.h>
+#include <sensor_msgs/NavSatFix.h>
+#include <gps_common/conversions.h>
+#include <nav_msgs/Odometry.h>
+
+using namespace gps_common;
+
+static ros::Publisher fix_pub;
+std::string frame_id, child_frame_id;
+double rot_cov;
+
+void callback(const nav_msgs::OdometryConstPtr& odom) {
+
+  if (odom->header.stamp == ros::Time(0)) {
+    return;
+  }
+
+  if (!fix_pub) {
+    return;
+  }
+
+  double northing, easting, latitude, longitude;
+  std::string zone;
+
+  northing = odom->pose.pose.position.y;
+  easting = odom->pose.pose.position.x;
+
+  std::size_t pos = odom->header.frame_id.find("/utm_");
+  if(pos==std::string::npos) {
+    ROS_WARN("UTM zone not found in frame_id");
+    return;
+  }
+  zone = odom->header.frame_id.substr(pos + 5, 3);
+
+  ROS_INFO("%s", zone.c_str());
+
+  sensor_msgs::NavSatFix fix;
+  fix.header.frame_id = odom->header.frame_id.substr(0, pos);
+  fix.header.stamp = odom->header.stamp;
+
+  UTMtoLL(northing, easting, zone, latitude, longitude);
+
+  fix.latitude = latitude;
+  fix.longitude = longitude; 
+
+  fix_pub.publish(fix);
+}
+
+int main (int argc, char **argv) {
+  ros::init(argc, argv, "reverse_utm_odometry_node");
+  ros::NodeHandle node;
+  ros::NodeHandle priv_node("~");
+
+  priv_node.param<std::string>("frame_id", frame_id, "");
+
+  fix_pub = node.advertise<sensor_msgs::NavSatFix>("fix", 10);
+
+  ros::Subscriber odom_sub = node.subscribe("odom", 10, callback);
+
+  ros::spin();
+}
+

--- a/gps_common/src/reverse_utm_odometry_node.cpp
+++ b/gps_common/src/reverse_utm_odometry_node.cpp
@@ -1,5 +1,7 @@
 /*
- * Translates nav_msgs/Odometry into sensor_msgs/NavSat{Fix,Status}
+ * Translates nav_msgs/Odometry in UTM coordinates back into sensor_msgs/NavSat{Fix,Status}
+ * Useful for visualizing UTM data on a map or comparing with raw GPS data
+ * Added by Dheera Venkatraman (dheera@dheera.net)
  */
 
 #include <ros/ros.h>
@@ -49,6 +51,19 @@ void callback(const nav_msgs::OdometryConstPtr& odom) {
 
   fix.latitude = latitude;
   fix.longitude = longitude; 
+  fix.altitude = odom->pose.pose.position.z;
+
+  fix.position_covariance[0] = odom->pose.covariance[0];
+  fix.position_covariance[1] = odom->pose.covariance[1];
+  fix.position_covariance[2] = odom->pose.covariance[2];
+  fix.position_covariance[3] = odom->pose.covariance[6];
+  fix.position_covariance[4] = odom->pose.covariance[7];
+  fix.position_covariance[5] = odom->pose.covariance[8];
+  fix.position_covariance[6] = odom->pose.covariance[12];
+  fix.position_covariance[7] = odom->pose.covariance[13];
+  fix.position_covariance[8] = odom->pose.covariance[14];
+  
+  fix.status.status = sensor_msgs::NavSatStatus::STATUS_FIX;
 
   fix_pub.publish(fix);
 }
@@ -60,7 +75,7 @@ int main (int argc, char **argv) {
 
   priv_node.param<std::string>("frame_id", frame_id, "");
 
-  fix_pub = node.advertise<sensor_msgs::NavSatFix>("fix", 10);
+  fix_pub = node.advertise<sensor_msgs::NavSatFix>("reverse_fix", 10);
 
   ros::Subscriber odom_sub = node.subscribe("odom", 10, callback);
 

--- a/gps_common/src/utm_odometry_node.cpp
+++ b/gps_common/src/utm_odometry_node.cpp
@@ -36,9 +36,9 @@ void callback(const sensor_msgs::NavSatFixConstPtr& fix) {
     odom.header.stamp = fix->header.stamp;
 
     if (frame_id.empty())
-      odom.header.frame_id = fix->header.frame_id;
+      odom.header.frame_id = fix->header.frame_id + "/utm_" + zone;
     else
-      odom.header.frame_id = frame_id;
+      odom.header.frame_id = frame_id + "/utm_" + zone;
 
     odom.child_frame_id = child_frame_id;
 

--- a/gps_common/src/utm_odometry_node.cpp
+++ b/gps_common/src/utm_odometry_node.cpp
@@ -15,6 +15,7 @@ using namespace gps_common;
 static ros::Publisher odom_pub;
 std::string frame_id, child_frame_id;
 double rot_cov;
+bool append_zone = false;
 
 void callback(const sensor_msgs::NavSatFixConstPtr& fix) {
   if (fix->status.status == sensor_msgs::NavSatStatus::STATUS_NO_FIX) {
@@ -35,10 +36,19 @@ void callback(const sensor_msgs::NavSatFixConstPtr& fix) {
     nav_msgs::Odometry odom;
     odom.header.stamp = fix->header.stamp;
 
-    if (frame_id.empty())
-      odom.header.frame_id = fix->header.frame_id + "/utm_" + zone;
-    else
-      odom.header.frame_id = frame_id + "/utm_" + zone;
+    if (frame_id.empty()) {
+      if(append_zone) {
+        odom.header.frame_id = fix->header.frame_id + "/utm_" + zone;
+      } else {
+        odom.header.frame_id = fix->header.frame_id;
+      }
+    } else {
+      if(append_zone) {
+        odom.header.frame_id = frame_id + "/utm_" + zone;
+      } else {
+        odom.header.frame_id = frame_id;
+      }
+    }
 
     odom.child_frame_id = child_frame_id;
 
@@ -84,6 +94,7 @@ int main (int argc, char **argv) {
   priv_node.param<std::string>("frame_id", frame_id, "");
   priv_node.param<std::string>("child_frame_id", child_frame_id, "");
   priv_node.param<double>("rot_covariance", rot_cov, 99999.0);
+  priv_node.param<bool>("append_zone", append_zone, true);
 
   odom_pub = node.advertise<nav_msgs::Odometry>("odom", 10);
 


### PR DESCRIPTION
Adding the UTM zone to the frame_id (e.g. frame_id/utm_10S) ensures that no data is lost (i.e. odometry message is self-contained) when conversion is made from NavSatFix to Odometry. This also helps differentiate Odometry data that can be theoretically specified in two different ways in overlapping UTM zones.

Also added a reverse_utm_odometry_node that reverses the UTM odometry data back into a NavSatFix which is extremely useful for NavSatFix-compatible map visualization tools to be able to directly visualize Odometry data in UTM format.