### PR TITLE
Add parameter to set frame_id.

### DIFF
--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -10,7 +10,7 @@ using namespace sensor_msgs;
 
 class GPSDClient {
   public:
-    GPSDClient() : privnode("~"), gps(NULL), use_gps_time(true), check_fix_by_variance(true) {}
+    GPSDClient() : privnode("~"), gps(NULL), use_gps_time(true), check_fix_by_variance(true), frame_id("gps") {}
 
     bool start() {
       gps_fix_pub = node.advertise<GPSFix>("extended_fix", 1);
@@ -18,6 +18,7 @@ class GPSDClient {
 
       privnode.getParam("use_gps_time", use_gps_time);
       privnode.getParam("check_fix_by_variance", check_fix_by_variance);
+      privnode.param("frame_id", frame_id, frame_id);
 
       std::string host = "localhost";
       int port = 2947;
@@ -76,6 +77,7 @@ class GPSDClient {
 
     bool use_gps_time;
     bool check_fix_by_variance;
+    std::string frame_id;
 
     void process_data(struct gps_data_t* p) {
       if (p == NULL)
@@ -105,6 +107,7 @@ class GPSDClient {
 
       status.header.stamp = time;
       fix.header.stamp = time;
+      fix.header.frame_id = frame_id;
 
       status.satellites_used = p->satellites_used;
 
@@ -196,6 +199,8 @@ class GPSDClient {
         fix->header.stamp = ros::Time(p->fix.time);
       else
         fix->header.stamp = ros::Time::now();
+
+      fix->header.frame_id = frame_id;
 
       /* gpsmm pollutes the global namespace with STATUS_,
        * so we need to use the ROS message's integer values


### PR DESCRIPTION
frame_id is now set by default to "gps". This was tested with a bu-353 GPS.

Fixes #7 .