### PR TITLE
Fix for gpsd-3.19 compatibility

### DIFF
--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -175,7 +175,11 @@ class GPSDClient {
         fix.gdop = p->gdop;
 #endif
 
+#if GPSD_API_MAJOR_VERSION < 8
+        fix.err = p->epe;
+#else
         fix.err = p->fix.eph;
+#endif
         fix.err_vert = p->fix.epv;
         fix.err_track = p->fix.epd;
         fix.err_speed = p->fix.eps;

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -175,7 +175,7 @@ class GPSDClient {
         fix.gdop = p->gdop;
 #endif
 
-        fix.err = p->epe;
+        fix.err = p->fix.eph;
         fix.err_vert = p->fix.epv;
         fix.err_track = p->fix.epd;
         fix.err_speed = p->fix.eps;


### PR DESCRIPTION
Fix for https://github.com/swri-robotics/gps_umd/issues/25 , based on the documented changes in `/usr/include/gps.h`