### PR TITLE
Add support for ros1 bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Only adjust the topic names after "to=" in each remap line.
 Use with ros1_bridge
 --------------------------------
 
-The [ros1_bridge](https://index.ros.org/p/ros1_bridge/) package must be built from source to enable playback of GPSFix and GPSStatus messages stored in ROS1 bags.
+The [ros1_bridge](https://index.ros.org/p/ros1_bridge/) package must be built from source to enable playback of GPSFix and GPSStatus messages stored in ROS1 bags. This requires that the applicable ROS1 `gps_common` and ROS2 `gps_msgs` packages are first installed.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ The node `fix_translator` converts [sensor_msgs/NavSatFix](http://docs.ros.org/a
 ```
 
 Only adjust the topic names after "to=" in each remap line.
+
+Use with ros1_bridge
+--------------------------------
+
+The [ros1_bridge](https://index.ros.org/p/ros1_bridge/) package must be built from source to enable playback of GPSFix and GPSStatus messages stored in ROS1 bags.

--- a/gps_msgs/CHANGELOG.rst
+++ b/gps_msgs/CHANGELOG.rst
@@ -1,6 +1,9 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package gps_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1.0.4 (Unreleased)
+------------------
+* Added mappings to the messages in the ROS gps_common package for use with ros1_bridge
 
 1.0.3 (2020-06-10)
 ------------------

--- a/gps_msgs/CHANGELOG.rst
+++ b/gps_msgs/CHANGELOG.rst
@@ -1,7 +1,7 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package gps_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-1.0.4 (Unreleased)
+Forthcoming
 ------------------
 * Added mappings to the messages in the ROS gps_common package for use with ros1_bridge
 

--- a/gps_msgs/CMakeLists.txt
+++ b/gps_msgs/CMakeLists.txt
@@ -21,3 +21,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()
+
+install(
+  FILES ros1_ros2_mapping.yaml
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/gps_msgs/package.xml
+++ b/gps_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>gps_msgs</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <description>GPS messages for use in GPS drivers</description>
 
   <maintainer email="preed@swri.org">P. J. Reed</maintainer>
@@ -20,5 +20,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <ros1_bridge mapping_rules="ros1_ros2_mapping.yaml"/>
   </export>
 </package>

--- a/gps_msgs/package.xml
+++ b/gps_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>gps_msgs</name>
-  <version>1.0.4</version>
+  <version>1.0.3</version>
   <description>GPS messages for use in GPS drivers</description>
 
   <maintainer email="preed@swri.org">P. J. Reed</maintainer>

--- a/gps_msgs/ros1_ros2_mapping.yaml
+++ b/gps_msgs/ros1_ros2_mapping.yaml
@@ -1,0 +1,3 @@
+-
+  ros1_package_name: 'gps_common'
+  ros2_package_name: 'gps_msgs'


### PR DESCRIPTION
This adds the mapping file necessary for ros1_bridge to be able to read GPSFix and GPSStatus messages from ROS1 bags. The ros1_bridge must be built locally. 