### PR TITLE
fix status on /extended_fix topic for DGPS and RTK.

### DIFF
--- a/gps_common/msg/GPSStatus.msg
+++ b/gps_common/msg/GPSStatus.msg
@@ -17,8 +17,6 @@ int16 STATUS_FIX=0       # Normal fix
 int16 STATUS_SBAS_FIX=1  # Fixed using a satellite-based augmentation system
 int16 STATUS_GBAS_FIX=2  #          or a ground-based augmentation system
 int16 STATUS_DGPS_FIX=18 # Fixed with DGPS
-int16 STATUS_RTK_FIX=19  # Real-Time Kinematic, fixed integers
-int16 STATUS_RTK_FLT=20  # Real-Time Kinematic, float integers
 int16 STATUS_WAAS_FIX=33 # Fixed with WAAS
 int16 status
 

--- a/gps_common/msg/GPSStatus.msg
+++ b/gps_common/msg/GPSStatus.msg
@@ -17,6 +17,8 @@ int16 STATUS_FIX=0       # Normal fix
 int16 STATUS_SBAS_FIX=1  # Fixed using a satellite-based augmentation system
 int16 STATUS_GBAS_FIX=2  #          or a ground-based augmentation system
 int16 STATUS_DGPS_FIX=18 # Fixed with DGPS
+int16 STATUS_RTK_FIX=19  # Real-Time Kinematic, fixed integers
+int16 STATUS_RTK_FLT=20  # Real-Time Kinematic, float integers
 int16 STATUS_WAAS_FIX=33 # Fixed with WAAS
 int16 status
 

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -148,14 +148,22 @@ class GPSDClient {
 #endif
       }
 
-      if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+      if ((p->status != STATUS_NO_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
         status.status = 0; // FIXME: gpsmm puts its constants in the global
                            // namespace, so `GPSStatus::STATUS_FIX' is illegal.
 
 // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
-#if GPSD_API_MAJOR_VERSION != 6
-        if (p->status & STATUS_DGPS_FIX)
-          status.status |= 18; // same here
+#ifdef STATUS_DGPS_FIX
+        if (p->status == STATUS_DGPS_FIX)
+          status.status = 18; // same here
+#endif
+#ifdef STATUS_RTK_FIX
+        if (p->status == STATUS_RTK_FIX)
+          status.status = 19; // same here
+#endif
+#ifdef STATUS_RTK_FLT
+        if (p->status == STATUS_RTK_FLT)
+          status.status = 20; // same here
 #endif
 
 #if GPSD_API_MAJOR_VERSION >= 9
@@ -236,7 +244,7 @@ class GPSDClient {
           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
           break;
 // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
-#if GPSD_API_MAJOR_VERSION != 6 
+#ifdef STATUS_DGPS_FIX
         case STATUS_DGPS_FIX:
           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
           break;

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -157,14 +157,6 @@ class GPSDClient {
         if (p->status == STATUS_DGPS_FIX)
           status.status = 18; // same here
 #endif
-#ifdef STATUS_RTK_FIX
-        if (p->status == STATUS_RTK_FIX)
-          status.status = 19; // same here
-#endif
-#ifdef STATUS_RTK_FLT
-        if (p->status == STATUS_RTK_FLT)
-          status.status = 20; // same here
-#endif
 
 #if GPSD_API_MAJOR_VERSION >= 9
         fix.time = (double)(p->fix.time.tv_sec) + (double)(p->fix.time.tv_nsec) / 1000000.;


### PR DESCRIPTION
When status is DGPS or RTK fix the field status.status in the /extended_fix topic currently returns -1/STATUS_NO_FIX. This PR should fix that.

For DGPS: My gpsd is GPSD_API_MAJOR_VERSION=6 and has STATUS_DGPS_FIX so use ifdef instead

Disclaimer: My gpsd does not have STATUS_RTK_FIX and STATUS_RTK_FLT yet, so this part is untested. At least it now reports 0/STATUS_FIX for RTK.