### PR TITLE
General CMake cleanup, Resolves Missing Dependency

### DIFF
--- a/gps_common/CMakeLists.txt
+++ b/gps_common/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(gps_common CXX)
+project(gps_common)
 
 ############
 ## Catkin ##
@@ -51,37 +51,29 @@ catkin_package(
 ###########
 ## Build ##
 ###########
+include_directories(${catkin_INCLUDE_DIRS})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${catkin_INCLUDE_DIRS})
-
-add_executable(${PROJECT_NAME}/utm_odometry_node src/utm_odometry_node.cpp)
-add_executable(${PROJECT_NAME}/utm_odometry_to_navsatfix_node src/utm_odometry_to_navsatfix_node.cpp)
-
-set_target_properties(${PROJECT_NAME}/utm_odometry_node PROPERTIES OUTPUT_NAME "utm_odometry_node")
-target_link_libraries(${PROJECT_NAME}/utm_odometry_node ${catkin_LIBRARIES})
-
-set_target_properties(${PROJECT_NAME}/utm_odometry_to_navsatfix_node PROPERTIES OUTPUT_NAME "utm_odometry_to_navsatfix_node")
-target_link_libraries(${PROJECT_NAME}/utm_odometry_to_navsatfix_node ${catkin_LIBRARIES})
-
-add_dependencies(${PROJECT_NAME}/utm_odometry_node
-  ${PROJECT_NAME}_generate_messages_cpp 
-  ${catkin_EXPORTED_TARGETS} 
+add_executable(utm_odometry_node src/utm_odometry_node.cpp)
+add_dependencies(utm_odometry_node
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
-)
-
-add_dependencies(${PROJECT_NAME}/utm_odometry_to_navsatfix_node
-  ${PROJECT_NAME}_generate_messages_cpp 
   ${catkin_EXPORTED_TARGETS} 
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
 )
+target_link_libraries(utm_odometry_node ${catkin_LIBRARIES})
+
+add_executable(utm_odometry_to_navsatfix_node src/utm_odometry_to_navsatfix_node.cpp)
+add_dependencies(utm_odometry_to_navsatfix_node
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS} 
+)
+target_link_libraries(utm_odometry_to_navsatfix_node ${catkin_LIBRARIES})
 
 #############
 ## Install ##
 #############
 
 install(TARGETS
-  ${PROJECT_NAME}/utm_odometry_node
-  ${PROJECT_NAME}/utm_odometry_to_navsatfix_node
+  utm_odometry_node
+  utm_odometry_to_navsatfix_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/gps_common/package.xml
+++ b/gps_common/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>gps_common</name>
   <version>0.3.2</version>
   <description>GPS messages and common routines for use in GPS drivers</description>
@@ -11,20 +11,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>message_filters</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>rospy</build_depend>
 
-  <run_depend>message_filters</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>rospy</run_depend>
+  <depend>message_filters</depend>
+  <depend>nav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>rospy</depend>
 
+  <exec_depend>message_runtime</exec_depend>
 </package>

--- a/gpsd_client/CMakeLists.txt
+++ b/gpsd_client/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(gpsd_client CXX)
+project(gpsd_client)
 
 ############
 ## Catkin ##
@@ -18,7 +18,12 @@ pkg_check_modules (libgps REQUIRED libgps)
 ## Declare things to be passed to other projects ##
 ###################################################
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    gps_common
+    roscpp
+    sensor_msgs
+)
 
 ###########
 ## Build ##
@@ -26,6 +31,7 @@ catkin_package()
 
 include_directories(${catkin_INCLUDE_DIRS} ${libgps_INCLUDE_DIRS})
 add_executable(${PROJECT_NAME} src/client.cpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${libgps_LIBRARIES})
 
 #############

--- a/gpsd_client/package.xml
+++ b/gpsd_client/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>gpsd_client</name>
   <version>0.3.2</version>
   <description>connects to a GPSd server and broadcasts GPS fixes 
@@ -14,11 +14,11 @@
   <url type="website">http://ros.org/wiki/gpsd_client</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-
-  <build_depend>roscpp</build_depend>
-  <build_depend>gps_common</build_depend>
-  <build_depend>sensor_msgs</build_depend>
   <build_depend>pkg-config</build_depend>
-  <build_depend>libgps</build_depend>
+
+  <depend>gps_common</depend>
+  <depend>libgps</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
 
 </package>


### PR DESCRIPTION
Cleans up the CMake and package.xml files in general, and correctly specifies the missing transitory dependency that could sometimes builds to fail because messages were not being built before packages, as noted in this issue: https://github.com/swri-robotics/gps_umd/issues/37