### PR TITLE
Disable truncation warning for UTM zone snprintf()

### DIFF
--- a/gps_common/include/gps_common/conversions.h
+++ b/gps_common/include/gps_common/conversions.h
@@ -183,7 +183,10 @@ static inline void LLtoUTM(const double Lat, const double Long,
 	LongOriginRad = LongOrigin * RADIANS_PER_DEGREE;
 
 	//compute the UTM Zone from the latitude and longitude
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 	snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
+#pragma GCC diagnostic pop
 
 	eccPrimeSquared = (eccSquared)/(1-eccSquared);
 


### PR DESCRIPTION
```
In file included from /home/kmhallen/ros1/ds/src/gps_umd/gps_common/src/utm_odometry_node.cpp:10:
/home/kmhallen/ros1/ds/src/gps_umd/gps_common/include/gps_common/conversions.h: In function ‘void callback(const NavSatFixConstPtr&)’:
/home/kmhallen/ros1/ds/src/gps_umd/gps_common/include/gps_common/conversions.h:188:24: warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 4 [-Wformat-truncation=]
  188 |  snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
      |                        ^~
/home/kmhallen/ros1/ds/src/gps_umd/gps_common/include/gps_common/conversions.h:188:23: note: directive argument in the range [-2147483647, 2147483647]
  188 |  snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
      |                       ^~~~~~
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /opt/ros/noetic/include/ros/platform.h:38,
                 from /opt/ros/noetic/include/ros/time.h:53,
                 from /opt/ros/noetic/include/ros/ros.h:38,
                 from /home/kmhallen/ros1/ds/src/gps_umd/gps_common/src/utm_odometry_node.cpp:5:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 3 and 13 bytes into a destination of size 4
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```