### PR TITLE
Disable truncation warning for UTM zone snprintf()

### DIFF
--- a/gps_tools/include/gps_tools/conversions.h
+++ b/gps_tools/include/gps_tools/conversions.h
@@ -183,7 +183,10 @@ static inline void LLtoUTM(const double Lat, const double Long,
 	LongOriginRad = LongOrigin * RADIANS_PER_DEGREE;
 
 	//compute the UTM Zone from the latitude and longitude
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 	snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
+#pragma GCC diagnostic pop
 
 	eccPrimeSquared = (eccSquared)/(1-eccSquared);
 


### PR DESCRIPTION
```
In file included from /home/kmhallen/ros2/ds/src/gps_umd/gps_tools/src/utm_odometry_component.cpp:9:
/home/kmhallen/ros2/ds/src/gps_umd/gps_tools/include/gps_tools/conversions.h: In lambda function:
/home/kmhallen/ros2/ds/src/gps_umd/gps_tools/include/gps_tools/conversions.h:186:24: warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 4 [-Wformat-truncation=]
  186 |  snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
      |                        ^~
/home/kmhallen/ros2/ds/src/gps_umd/gps_tools/include/gps_tools/conversions.h:186:23: note: directive argument in the range [-2147483647, 2147483647]
  186 |  snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
      |                       ^~~~~~
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /usr/include/c++/9/stdexcept:39,
                 from /usr/include/c++/9/array:39,
                 from /usr/include/c++/9/tuple:39,
                 from /usr/include/c++/9/bits/unique_ptr.h:37,
                 from /usr/include/c++/9/memory:80,
                 from /opt/ros/foxy/include/rclcpp/rclcpp.hpp:144,
                 from /home/kmhallen/ros2/ds/src/gps_umd/gps_tools/src/utm_odometry_component.cpp:5:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 3 and 13 bytes into a destination of size 4
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```