### PR TITLE
A few build improvements and code cleanup changes

### DIFF
--- a/gpsd_client/CMakeLists.txt
+++ b/gpsd_client/CMakeLists.txt
@@ -11,8 +11,26 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
-find_package(PkgConfig)
-pkg_check_modules (libgps REQUIRED libgps)
+# Try to find libgps, first with CMake's usual library search method, then by
+# querying pkg-config.
+find_library(libgps_LIBRARIES NAMES gps)
+find_path(libgps_INCLUDE_DIRS NAMES libgpsmm.h gps.h)
+
+if(NOT libgps_LIBRARIES)
+  message(STATUS "Checking pkg-config for libgps")
+  find_package(PkgConfig)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(libgps libgps)
+  endif()
+endif()
+
+if(NOT libgps_LIBRARIES)
+  message(FATAL_ERROR "Could not find libgps "
+                      "(hint for Debian/Ubuntu: apt install libgps-dev)")
+else()
+  message(STATUS "Found libgps: ${libgps_LIBRARIES}")
+endif()
+
 
 ###################################################
 ## Declare things to be passed to other projects ##

--- a/gpsd_client/package.xml
+++ b/gpsd_client/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>gpsd_client</name>
   <version>0.3.4</version>
   <description>connects to a GPSd server and broadcasts GPS fixes 
@@ -16,9 +16,10 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
-  <build_depend>gps_common</build_depend>
-  <build_depend>sensor_msgs</build_depend>
   <build_depend>pkg-config</build_depend>
   <build_depend>libgps</build_depend>
+
+  <depend>gps_common</depend>
+  <depend>sensor_msgs</depend>
 
 </package>

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -219,23 +219,23 @@ class GPSDClient {
     }
 
     void process_data_navsat(struct gps_data_t* p) {
-      NavSatFixPtr fix(new NavSatFix);
+      NavSatFix fix;
 
       /* TODO: Support SBAS and other GBAS. */
 
 #if GPSD_API_MAJOR_VERSION >= 9
       if (use_gps_time && (p->online.tv_sec || p->online.tv_nsec)) {
-        fix->header.stamp = ros::Time(p->fix.time.tv_sec, p->fix.time.tv_nsec);
+        fix.header.stamp = ros::Time(p->fix.time.tv_sec, p->fix.time.tv_nsec);
 #else
       if (use_gps_time && !std::isnan(p->fix.time)) {
-        fix->header.stamp = ros::Time(p->fix.time);
+        fix.header.stamp = ros::Time(p->fix.time);
 #endif
       }
       else {
-        fix->header.stamp = ros::Time::now();
+        fix.header.stamp = ros::Time::now();
       }
 
-      fix->header.frame_id = frame_id;
+      fix.header.frame_id = frame_id;
 
       /* gpsmm pollutes the global namespace with STATUS_,
        * so we need to use the ROS message's integer values
@@ -251,7 +251,7 @@ class GPSDClient {
 #else
         case STATUS_NO_FIX:
 #endif
-          fix->status.status = 0; // NavSatStatus::STATUS_FIX or NavSatStatus::STATUS_GPS;
+          fix.status.status = 0; // NavSatStatus::STATUS_FIX or NavSatStatus::STATUS_GPS;
           break;
 // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward and next renamed since the version 12
 #if GPSD_API_MAJOR_VERSION != 6
@@ -260,16 +260,16 @@ class GPSDClient {
 #else
         case STATUS_DGPS_FIX:
 #endif
-          fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+          fix.status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
           break;
 #endif
       }
 
-      fix->status.service = NavSatStatus::SERVICE_GPS;
+      fix.status.service = NavSatStatus::SERVICE_GPS;
 
-      fix->latitude = p->fix.latitude;
-      fix->longitude = p->fix.longitude;
-      fix->altitude = p->fix.altitude;
+      fix.latitude = p->fix.latitude;
+      fix.longitude = p->fix.longitude;
+      fix.altitude = p->fix.altitude;
 
       /* gpsd reports status=OK even when there is no current fix,
        * as long as there has been a fix previously. Throw out these
@@ -281,11 +281,11 @@ class GPSDClient {
         return;
       }
 
-      fix->position_covariance[0] = p->fix.epx;
-      fix->position_covariance[4] = p->fix.epy;
-      fix->position_covariance[8] = p->fix.epv;
+      fix.position_covariance[0] = p->fix.epx;
+      fix.position_covariance[4] = p->fix.epy;
+      fix.position_covariance[8] = p->fix.epv;
 
-      fix->position_covariance_type = NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+      fix.position_covariance_type = NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
 
       navsat_fix_pub.publish(fix);
     }

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -1,9 +1,31 @@
+#include <libgpsmm.h>
+
+// gps.h defines some macros which conflict with enum values in NavSatStatus.h,
+// so we map them to new names before including other headers.
+#ifdef STATUS_FIX
+  enum {
+    GPSD_STATUS_NO_FIX   = STATUS_NO_FIX,
+    GPSD_STATUS_FIX      = STATUS_FIX,
+    GPSD_STATUS_DGPS_FIX = STATUS_DGPS_FIX,
+  };
+  #undef STATUS_NO_FIX
+  #undef STATUS_FIX
+  #undef STATUS_DGPS_FIX
+#else
+  // Renamed in gpsd >= 3.23.1 (commits d4a4d8d3, af3b7dc0, 7d7b889f) without
+  // revising the API version number.
+  enum {
+    GPSD_STATUS_NO_FIX   = STATUS_UNK,
+    GPSD_STATUS_FIX      = STATUS_GPS,
+    GPSD_STATUS_DGPS_FIX = STATUS_DGPS,
+  };
+#endif
+
 #include <ros/ros.h>
 #include <gps_common/GPSFix.h>
 #include <gps_common/GPSStatus.h>
 #include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/NavSatStatus.h>
-#include <libgpsmm.h>
 
 #include <cmath>
 
@@ -148,27 +170,22 @@ class GPSDClient {
 #endif
       }
 
-#if GPSD_API_MAJOR_VERSION >= 12
-      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
-#elif GPSD_API_MAJOR_VERSION >= 10
-      if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+#if GPSD_API_MAJOR_VERSION >= 10
+      if ((p->fix.status & GPSD_STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
 #else
-      if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+      if ((p->status & GPSD_STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
 #endif
 
-        status.status = 0; // FIXME: gpsmm puts its constants in the global
-                           // namespace, so `GPSStatus::STATUS_FIX' is illegal.
+        status.status = GPSStatus::STATUS_FIX;
 
-// STATUS_DGPS_FIX was removed in API version 6 but re-added afterward and next renamed since the version 12
+// STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
 #if GPSD_API_MAJOR_VERSION != 6
-#if GPSD_API_MAJOR_VERSION >= 12
-        if (p->fix.status & STATUS_DGPS)
-#elif GPSD_API_MAJOR_VERSION >= 10
-        if (p->fix.status & STATUS_DGPS_FIX)
+#if GPSD_API_MAJOR_VERSION >= 10
+        if (p->fix.status & GPSD_STATUS_DGPS_FIX)
 #else
-        if (p->status & STATUS_DGPS_FIX)
+        if (p->status & GPSD_STATUS_DGPS_FIX)
 #endif
-          status.status |= 18; // same here
+          status.status |= GPSStatus::STATUS_DGPS_FIX;
 #endif
 
 #if GPSD_API_MAJOR_VERSION >= 9
@@ -210,7 +227,7 @@ class GPSDClient {
 
         /* TODO: attitude */
       } else {
-        status.status = -1; // STATUS_NO_FIX or STATUS_UNK
+        status.status = GPSStatus::STATUS_NO_FIX;
       }
 
       fix.status = status;
@@ -237,30 +254,21 @@ class GPSDClient {
 
       fix.header.frame_id = frame_id;
 
-      /* gpsmm pollutes the global namespace with STATUS_,
-       * so we need to use the ROS message's integer values
-       * for status.status
-       */
 #if GPSD_API_MAJOR_VERSION >= 10
       switch (p->fix.status) {
 #else
       switch (p->status) {
 #endif
-#if GPSD_API_MAJOR_VERSION >= 12
-        case STATUS_GPS:
-#else
-        case STATUS_NO_FIX:
-#endif
-          fix.status.status = 0; // NavSatStatus::STATUS_FIX or NavSatStatus::STATUS_GPS;
+        case GPSD_STATUS_NO_FIX:
+          fix.status.status = NavSatStatus::STATUS_NO_FIX;
           break;
-// STATUS_DGPS_FIX was removed in API version 6 but re-added afterward and next renamed since the version 12
+        case GPSD_STATUS_FIX:
+          fix.status.status = NavSatStatus::STATUS_FIX;
+          break;
+// STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
 #if GPSD_API_MAJOR_VERSION != 6
-#if GPSD_API_MAJOR_VERSION >= 12
-        case STATUS_DGPS:
-#else
-        case STATUS_DGPS_FIX:
-#endif
-          fix.status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+        case GPSD_STATUS_DGPS_FIX:
+          fix.status.status = NavSatStatus::STATUS_GBAS_FIX;
           break;
 #endif
       }

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -27,6 +27,7 @@
 #include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/NavSatStatus.h>
 
+#include <cstdlib>
 #include <cmath>
 
 using namespace gps_common;
@@ -45,12 +46,12 @@ class GPSDClient {
       privnode.param("frame_id", frame_id, frame_id);
 
       std::string host = "localhost";
-      int port = 2947;
+      int port = atoi(DEFAULT_GPSD_PORT);
       privnode.getParam("host", host);
       privnode.getParam("port", port);
 
       char port_s[12];
-      snprintf(port_s, 12, "%d", port);
+      snprintf(port_s, sizeof(port_s), "%d", port);
 
       gps_data_t *resp = NULL;
 

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -90,7 +90,7 @@ class GPSDClient {
     }
 
     void stop() {
-      // gpsmm doesn't have a close method? OK ...
+      delete gps;
     }
 
   private:

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -294,7 +294,9 @@ class GPSDClient {
       fix.position_covariance[4] = p->fix.epy;
       fix.position_covariance[8] = p->fix.epv;
 
-      fix.position_covariance_type = NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+      fix.position_covariance_type = std::isnan(p->fix.epx) ?
+        NavSatFix::COVARIANCE_TYPE_UNKNOWN :
+        NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
 
       navsat_fix_pub.publish(fix);
     }


### PR DESCRIPTION
This pull request includes a few code cleanup changes. If you would prefer these as separate pull requests, please let me know.

1. Uses CMake's built-in `find_library` to find `libgps` rather than relying on `pkg-config`, which is not populated by default on Debian.

3. Upgrades `package.xml` to version 2 and promotes `sensor_msgs` and `gps_common` to runtime dependencies. Previously, these were only build time dependencies, which means that `ros-noetic-gpsd-client` will not auto-install `ros-noetic-gps-common` and hence the message definitions will not be available (`rostopic echo /extended_fix` will error, etc.)

4. Changes `process_data_navsat` to not allocate a new `NavSatFix` object each time. The `process_data_gps` function did not have this problem.

5. Provides a slightly hacky workaround to the fact that `gps.h` pollutes the global namespace with its macro definitions like `STATUS_NO_FIX`. This removes the need to hardcode the enum values for `NavSatStatus::STATUS_NO_FIX` etc.

6. Removes the hardcoded default port number and instead uses `DEFAULT_GPSD_PORT`.

7. Frees the allocated `gpsmm` instance when `stop()` is called, eliminating an extremely minor memory leak.