### PR TITLE
Ros2 devel for GPSD 3.21 and 3.22

### DIFF
--- a/gpsd_client/config/gpsd_client.yaml
+++ b/gpsd_client/config/gpsd_client.yaml
@@ -1,6 +1,6 @@
 gpsd_client:
   ros__parameters:
-    use_gps_time: true
-    check_fix_by_variance: true
+    use_gps_time: false
+    check_fix_by_variance: false
     frame_id: gps
     publish_rate: 10

--- a/gpsd_client/config/gpsd_client.yaml
+++ b/gpsd_client/config/gpsd_client.yaml
@@ -1,6 +1,6 @@
 gpsd_client:
   ros__parameters:
-    use_gps_time: false
-    check_fix_by_variance: false
+    use_gps_time: true
+    check_fix_by_variance: true
     frame_id: gps
     publish_rate: 10

--- a/gpsd_client/launch/gpsd_client-launch.py
+++ b/gpsd_client/launch/gpsd_client-launch.py
@@ -34,4 +34,12 @@ def generate_launch_description():
             output='screen',
     )
 
-    return launch.LaunchDescription([container])
+    return launch.LaunchDescription([container,
+            launch.actions.RegisterEventHandler(
+                event_handler=launch.event_handlers.OnProcessExit(
+                    target_action=container,
+                    on_exit=[launch.actions.EmitEvent(
+                        event=launch.events.Shutdown())]
+                    ))
+                ])
+

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -167,30 +167,16 @@ namespace gpsd_client
         status.satellite_visible_snr[i] = p->ss[i];
 #endif
       }
-#if GPSD_API_MAJOR_VERSION >= 10
-#ifdef STATUS_FIX
-      if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
-#else
-      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
-#endif
-#else
+
       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
-#endif
       {
         status.status = 0; // FIXME: gpsmm puts its constants in the global
         // namespace, so `GPSStatus::STATUS_FIX' is illegal.
 
 // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
 #if GPSD_API_MAJOR_VERSION != 6
-#if GPSD_API_MAJOR_VERSION >= 10
-#ifdef STATUS_DGPS_FIX
-      if (p->fix.status & STATUS_DGPS_FIX)
-#else
-      if (p->fix.status & STATUS_DGPS)
-#endif
-#else
-      if (p->status & STATUS_DGPS_FIX)
-#endif
+        if (p->status & STATUS_DGPS_FIX)
+          status.status |= 18; // same here
 #endif
 
 #if GPSD_API_MAJOR_VERSION >= 9
@@ -265,33 +251,17 @@ namespace gpsd_client
        * so we need to use the ROS message's integer values
        * for status.status
        */
-#if GPSD_API_MAJOR_VERSION >= 10
-      switch (p->fix.status)
-#else
       switch (p->status)
-#endif
       {
-#ifdef STATUS_NO_FIX
         case STATUS_NO_FIX:
-#else
-        case STATUS_UNK:
-#endif
           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
           break;
-#ifdef STATUS_FIX
         case STATUS_FIX:
-#else
-        case STATUS_GPS:
-#endif
           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
           break;
 // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
 #if GPSD_API_MAJOR_VERSION != 6
-#ifdef STATUS_DGPS_FIX
         case STATUS_DGPS_FIX:
-#else
-        case STATUS_DGPS:
-#endif
           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
           break;
 #endif


### PR DESCRIPTION
This PR fixes build issues with newer versions of GPSD, especially 3.21 and 3.22.
It also fixes a bug in the launch file where the module wasn't properly shut down after the process was killed.