### PR TITLE
Fixes CMake warning in downstream packages that depend on gps_tools

### DIFF
--- a/gps_tools/CMakeLists.txt
+++ b/gps_tools/CMakeLists.txt
@@ -76,6 +76,5 @@ ament_export_dependencies(ament_cmake
   rclpy
 )
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
With `find_package(gps_tools)` in another ROS 2 package, this CMake warning appears when building that other package:

```
CMake Warning at /opt/ros/galactic/share/gps_tools/cmake/ament_cmake_export_libraries-extras.cmake:116 (message):
  Package 'gps_tools' exports library 'gps_tools' which couldn't be found
Call Stack (most recent call first):
  /opt/ros/galactic/share/gps_tools/cmake/gps_toolsConfig.cmake:41 (include)
  CMakeLists.txt:18 (find_package)

```

I narrowed it down to the `ament_export_libraries` command in `CMakeLists.txt` of `gps_tools` which tries to export the `gps_tools` library that isn't built.

This PR simply removes the `ament_export_libraries` command, which doesn't seem to be necessary anyway.