### PR TITLE
Fix Colcon Build Warnings

### DIFF
--- a/gps_umd/package.xml
+++ b/gps_umd/package.xml
@@ -15,4 +15,8 @@
   <exec_depend>gpsd_client</exec_depend>
   <exec_depend>gps_msgs</exec_depend>
   <exec_depend>gps_tools</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Colcon emits the following warnings when building due to the build type not getting exported in the metapackage.

```
CMake Warning:
  Manually-specified variables were not used by the project:

    CATKIN_INSTALL_INTO_PREFIX_ROOT
    CATKIN_SYMLINK_INSTALL
```