### PR TITLE
Backporting CMake and package.xml fixes

### DIFF
--- a/gps_tools/CMakeLists.txt
+++ b/gps_tools/CMakeLists.txt
@@ -48,11 +48,6 @@ ament_target_dependencies(utm_odometry_to_navsatfix_component
   "sensor_msgs"
 )
 
-if(NOT WIN32)
-  ament_environment_hooks(
-    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}")
-endif()
-
 install(TARGETS
     utm_odometry_component
     utm_odometry_to_navsatfix_component

--- a/gps_umd/package.xml
+++ b/gps_umd/package.xml
@@ -16,4 +16,8 @@
   <exec_depend>gpsd_client</exec_depend>
   <exec_depend>gps_msgs</exec_depend>
   <exec_depend>gps_tools</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Backports a couple of fixes from the `ros2-devel` branch that fix some incorrect CMake usage and warnings.