### PR TITLE
Fix uninitialized parameter exception in gpsd_client

### DIFF
--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -30,12 +30,12 @@ namespace gpsd_client
 
     bool start()
     {
-      this->declare_parameter<bool>("use_gps_time");
-      this->declare_parameter<bool>("check_fix_by_variance");
-      this->declare_parameter<std::string>("frame_id");
-      this->declare_parameter<int>("publish_rate");
-      this->declare_parameter<std::string>("host");
-      this->declare_parameter<int>("port");
+      this->declare_parameter("use_gps_time", rclcpp::PARAMETER_BOOL);
+      this->declare_parameter("check_fix_by_variance", rclcpp::PARAMETER_BOOL);
+      this->declare_parameter("frame_id", rclcpp::PARAMETER_STRING);
+      this->declare_parameter("publish_rate", rclcpp::PARAMETER_INTEGER);
+      this->declare_parameter("host", rclcpp::PARAMETER_STRING);
+      this->declare_parameter("port", rclcpp::PARAMETER_INTEGER);
 
       gps_fix_pub_ = create_publisher<gps_msgs::msg::GPSFix>("extended_fix", 1);
       navsatfix_pub_ = create_publisher<sensor_msgs::msg::NavSatFix>("fix", 1);


### PR DESCRIPTION
When trying to run the constructor throws an exception: "Component constructor threw an exception: Statically typed parameter 'use_gps_time' must be initialized."

This problem is described here:
https://github.com/ros2/rclcpp/issues/1691

Solve this by using the non-template way of declaring the parameters.