### PR TITLE
Fix queue build up issue in gpsd_client

### DIFF
--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -86,7 +86,13 @@ namespace gpsd_client
       if (!gps_->waiting(1e6))
         return;
 
-      gps_data_t* p = gps_->read();
+      // Read out all queued data and only act on the latest
+      gps_data_t* p = NULL;
+      while (gps_->waiting(0))
+      {
+        p = gps_->read();
+      }
+
 #else
       gps_data_t *p = gps->poll();
 #endif


### PR DESCRIPTION
In step() which is called periodically according to the parameter publish_rate we only perform read() once, which means that there could still be more unprocessed data from gpsd waiting. This leads to a build up of unprocessed data causing the published data to be old and outdated.

By instead using the waiting() call to see if there's more data to be processed we can make sure that what we publish is actually the newest available data.