### PR TITLE
Added GPSExtendedStatus msg to allow for additional status enums

### DIFF
--- a/gps_common/CMakeLists.txt
+++ b/gps_common/CMakeLists.txt
@@ -28,6 +28,7 @@ catkin_python_setup()
 add_message_files(
   FILES
     GPSStatus.msg
+    GPSExtendedStatus.msg
     GPSFix.msg
 )
 

--- a/gps_common/msg/GPSExtendedStatus.msg
+++ b/gps_common/msg/GPSExtendedStatus.msg
@@ -1,0 +1,9 @@
+# Extended Measurement status to use for GPSStatus.msg
+int16 STATUS_NO_FIX=-1    # Unable to fix position
+int16 STATUS_FIX=0        # Normal fix
+int16 STATUS_SBAS_FIX=1   # Fixed using a satellite-based augmentation system
+int16 STATUS_GBAS_FIX=2   #          or a ground-based augmentation system
+int16 STATUS_DGPS_FIX=18  # Fixed with DGPS
+int16 STATUS_RTK_FIX=19   # Real-Time Kinematic, fixed integers
+int16 STATUS_RTK_FLOAT=20 # Real-Time Kinematic, float integers
+int16 STATUS_WAAS_FIX=33  # Fixed with WAAS


### PR DESCRIPTION
I wanted to add RTK Fix/Float into the GPSStatus message, but #34 already attempted to do this. The drawback is that the md5sum would change and it would potentially be burdensome to all users with previous bag data.

I think a reasonable workaround is the approach I have here. I added a new message that only defines enums. This way anyone can use the extended enums if they wish and they'll be standardized.