### PR TITLE
Added RTK fix/float enums

### DIFF
--- a/gps_msgs/msg/GPSStatus.msg
+++ b/gps_msgs/msg/GPSStatus.msg
@@ -12,12 +12,14 @@ int32[] satellite_visible_azimuth # Azimuth of satellites
 int32[] satellite_visible_snr # Signal-to-noise ratios (dB)
 
 # Measurement status
-int16 STATUS_NO_FIX=-1   # Unable to fix position
-int16 STATUS_FIX=0       # Normal fix
-int16 STATUS_SBAS_FIX=1  # Fixed using a satellite-based augmentation system
-int16 STATUS_GBAS_FIX=2  #          or a ground-based augmentation system
-int16 STATUS_DGPS_FIX=18 # Fixed with DGPS
-int16 STATUS_WAAS_FIX=33 # Fixed with WAAS
+int16 STATUS_NO_FIX=-1    # Unable to fix position
+int16 STATUS_FIX=0        # Normal fix
+int16 STATUS_SBAS_FIX=1   # Fixed using a satellite-based augmentation system
+int16 STATUS_GBAS_FIX=2   #          or a ground-based augmentation system
+int16 STATUS_DGPS_FIX=18  # Fixed with DGPS
+int16 STATUS_RTK_FIX=19   # Real-Time Kinematic, fixed integers
+int16 STATUS_RTK_FLOAT=20 # Real-Time Kinematic, float integers
+int16 STATUS_WAAS_FIX=33  # Fixed with WAAS
 int16 status
 
 uint16 SOURCE_NONE=0 # No information is available


### PR DESCRIPTION
Similar to #93, but for ROS2. I think given the dynamic nature of bags in ROS2, that a changing md5sum won't be that bad to deal with. So I propose we make the enum fix within the original message itself for ROS2.