### PR TITLE
Re-adding missing dependency

### DIFF
--- a/gpsd_client/package.xml
+++ b/gpsd_client/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>libgps</build_depend>
+  <build_depend>pkg-config</build_depend>
 
   <depend>gps_common</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
Re-adding pkg-config as a dependency to fix automatic dependency resolution.