### PR TITLE
Removing Obsolete ament Macros

### DIFF
--- a/gps_tools/CMakeLists.txt
+++ b/gps_tools/CMakeLists.txt
@@ -18,35 +18,42 @@ add_library(utm_odometry_component SHARED
   src/utm_odometry_component.cpp)
 target_include_directories(utm_odometry_component
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${rclcpp_components_INCLUDE_DIRS}
+    ${sensor_msgs_INCLUDE_DIRS}
+    ${nav_msgs_INCLUDE_DIRS}
 )
 target_compile_definitions(utm_odometry_component
   PRIVATE "COMPOSITION_BUILDING_DLL")
+
 rclcpp_components_register_nodes(utm_odometry_component "gps_tools::UtmOdometryComponent")
-ament_target_dependencies(utm_odometry_component
-  "nav_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-)
+target_link_libraries(utm_odometry_component PUBLIC
+  ${nav_msgs_LIBRARIES}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  ${sensor_msgs_LIBRARIES})
 
 add_library(utm_odometry_to_navsatfix_component SHARED
   src/utm_odometry_to_navsatfix_component.cpp)
+
 target_include_directories(utm_odometry_to_navsatfix_component
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${nav_msgs_INCLUDE_DIRS}
+    ${sensor_msgs_INCLUDE_DIRS}
 )
 target_compile_definitions(utm_odometry_to_navsatfix_component
   PRIVATE "COMPOSITION_BUILDING_DLL")
 rclcpp_components_register_nodes(utm_odometry_to_navsatfix_component "gps_tools::UtmOdometryToNavSatFixComponent")
-ament_target_dependencies(utm_odometry_to_navsatfix_component
-  "nav_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-)
+target_link_libraries(utm_odometry_to_navsatfix_component PUBLIC
+  ${nav_msgs_LIBRARIES}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  ${sensor_msgs_LIBRARIES})
 
 install(TARGETS
     utm_odometry_component

--- a/gpsd_client/CMakeLists.txt
+++ b/gpsd_client/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(gps_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_components REQUIRED rclcpp_components)
 find_package(sensor_msgs REQUIRED)
 
 # Try to find libgps, first with CMake's usual library search method, then by
@@ -31,25 +31,28 @@ else()
 endif()
 
 add_library(${PROJECT_NAME} SHARED
-  src/client.cpp
-)
+  src/client.cpp)
+
 target_include_directories(${PROJECT_NAME}
   PUBLIC
-  ${libgps_INCLUDE_DIRS}
-)
+    ${rclcpp_components_INCLUDE_DIRS}
+    ${libgps_INCLUDE_DIRS}
+    ${gps_msgs_INCLUDE_DIRS}
+    ${sensor_msgs_INCLUDE_DIRS})
+
 target_compile_definitions(${PROJECT_NAME}
-  PRIVATE "COMPOSITION_BUILDING_DLL"
-)
+  PRIVATE "COMPOSITION_BUILDING_DLL")
+
 rclcpp_components_register_nodes(${PROJECT_NAME} "gpsd_client::GPSDClientComponent")
-target_link_libraries(${PROJECT_NAME}
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${gps_msgs_LIBRARIES}
   ${libgps_LIBRARIES}
-)
-ament_target_dependencies(${PROJECT_NAME}
-  "gps_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-)
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  ${sensor_msgs_LIBRARIES})
+
 
 #############
 ## Install ##


### PR DESCRIPTION
Removes ament macros that are no longer supported and replaces them with the equivalent target_link_libraries commands.