### PR TITLE
Declare parameters so they correctly load.

### DIFF
--- a/gps_tools/src/utm_odometry_component.cpp
+++ b/gps_tools/src/utm_odometry_component.cpp
@@ -23,10 +23,10 @@ namespace gps_tools
     {
       odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("odom", 10);
 
-      get_parameter_or("rot_covariance", rot_cov_, rot_cov_);
-      get_parameter_or("child_frame_id", child_frame_id_, child_frame_id_);
-      get_parameter_or("frame_id", frame_id_, frame_id_);
-      get_parameter_or("append_zone", append_zone_, append_zone_);
+      rot_cov_ = declare_parameter("rot_covariance", rot_cov_);
+      child_frame_id_ = declare_parameter("child_frame_id", child_frame_id_);
+      frame_id_ = declare_parameter("frame_id", frame_id_);
+      append_zone_ = declare_parameter("append_zone", append_zone_);
 
       auto callback = [this](const typename sensor_msgs::msg::NavSatFix::SharedPtr fix) -> void
       {


### PR DESCRIPTION
### Description

On ros2-devel when I try to set a parameter for either of the components in `gps_tools`, the values I'm setting don't actually get used by the node. In my specific case, I was trying to set frame_ids on the odom message coming from `navsat_fix_to_odom`.

After some tracing I realized that the components in `gps_tools` were never declaring the parameters they were getting, so the default values were always being used.

This MR updates the components to declare the parameters.

The only odd part of this MR regards `zone` in `utm_odometry_to_navsatfix_component`. The code in ros2-develop expects to read it in as a string, but the value someone would actually put in a launch file is an int, and ros doesn't seem to know that ints can be converted to strings and just do that for us. To get around that, I switch the zone member variable to an optional with a default value of std::nullopt, declare the parameter with no default value, and catch the thrown exception if the user doesn't set the parameter.

### Verification

I wrote a custom launch file that loads both components and sets the parameters and verified the member variables were actually being modified by adding in some log statements which I removed. I also made sure the default values were still being used if I didn't set the parameters in my launch file. 