### PR TITLE
Implement Version Specific GPSd Parsers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,3 +18,47 @@ jobs:
       - uses: actions/checkout@v4
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}
+
+  # Build gpsd_client against several real gpsd releases and run its parser
+  # unit tests linked against each, exercising both parser variants. Unlike
+  # industrial_ci above (which matrixes over ROS distros against the system
+  # libgps), this matrixes over the gpsd/libgps ABI the client is built on.
+  gpsd_versions:
+    name: gpsd ${{ matrix.gpsd }}
+    # Only run when the ros2-devel branch itself is updated, not on every
+    # push or pull request (this job builds several gpsd releases from source).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/ros2-devel'
+    runs-on: ubuntu-latest
+    container: ros:kilted-ros-base
+    strategy:
+      fail-fast: false
+      matrix:
+        # One release per parser variant plus the latest tracked release:
+        #   3.20   -> API  9, GpsdParserV9  (minimum supported, V9 boundary)
+        #   3.21   -> API 10, GpsdParserV16 (first V16 release)
+        #   3.27.5 -> API 16, GpsdParserV16 (latest tested)
+        gpsd: ['3.20', '3.21', '3.27.5']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # tools/test_against_gpsd.sh assumes a <workspace>/src/<repo> layout.
+          path: src/gps_umd
+      - name: Install build tools and workspace dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends scons pkg-config
+          rosdep update
+          # Skip the system gpsd/libgps: the script builds libgps from source
+          # at ${{ matrix.gpsd }} and pins gpsd_client to that exact install.
+          rosdep install --from-paths src --ignore-src -y \
+            --skip-keys "libgps-dev gpsd"
+      - name: Cache gpsd builds
+        uses: actions/cache@v4
+        with:
+          path: .gpsd_versions
+          key: gpsd-${{ runner.os }}-${{ matrix.gpsd }}
+      - name: Build gpsd_client against gpsd ${{ matrix.gpsd }} and run parser tests
+        shell: bash
+        run: |
+          source /opt/ros/kilted/setup.bash
+          src/gps_umd/tools/test_against_gpsd.sh ${{ matrix.gpsd }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ jobs:
     strategy:
       matrix:
         env:
+          - {ROS_DISTRO: humble, ROS_REPO: testing}
+          - {ROS_DISTRO: humble, ROS_REPO: main}
           - {ROS_DISTRO: jazzy, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}
           - {ROS_DISTRO: jazzy, ROS_REPO: main, PIP_BREAK_SYSTEM_PACKAGES: True}
           - {ROS_DISTRO: kilted, ROS_REPO: testing, PIP_BREAK_SYSTEM_PACKAGES: True}

--- a/gpsd_client/CMakeLists.txt
+++ b/gpsd_client/CMakeLists.txt
@@ -35,6 +35,12 @@ add_library(${PROJECT_NAME} SHARED
   src/gpsd_parser_factory.cpp
   src/parsers/gpsd_parser_base.cpp)
 
+# Jazzy was the first distro to define an unknown fix, so this flag is used to correctly
+# initialize variables 
+if ("$ENV{ROS_DISTRO}" STRLESS "jazzy")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE "-DNO_UNKNOWN_FIX")
+endif()
+
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include

--- a/gpsd_client/CMakeLists.txt
+++ b/gpsd_client/CMakeLists.txt
@@ -31,10 +31,13 @@ else()
 endif()
 
 add_library(${PROJECT_NAME} SHARED
-  src/client.cpp)
+  src/client.cpp
+  src/gpsd_parser_factory.cpp
+  src/parsers/gpsd_parser_base.cpp)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC
+    include
     ${rclcpp_components_INCLUDE_DIRS}
     ${libgps_INCLUDE_DIRS}
     ${gps_msgs_INCLUDE_DIRS}
@@ -53,6 +56,16 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
+
+#############
+## Testing ##
+#############
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_gpsd_parser test/test_gpsd_parser.cpp)
+  target_link_libraries(test_gpsd_parser ${PROJECT_NAME})
+endif()
 
 #############
 ## Install ##

--- a/gpsd_client/include/gpsd_client/gpsd_parser.hpp
+++ b/gpsd_client/include/gpsd_client/gpsd_parser.hpp
@@ -1,0 +1,59 @@
+#ifndef GPSD_CLIENT__GPSD_PARSER_HPP_
+#define GPSD_CLIENT__GPSD_PARSER_HPP_
+
+#include <optional>
+#include <string>
+
+// NOTE: gps.h pollutes the global namespace with STATUS_* macros that
+// collide with the ROS message constants of the same names, so the message
+// headers must be included before it.
+#include <gps_msgs/msg/gps_fix.hpp>
+#include <rclcpp/time.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+
+#include <gps.h>
+
+#if GPSD_API_MAJOR_VERSION < 9
+#error "gpsd_client requires gpsd API version >= 9 (gpsd >= 3.20)"
+#endif
+
+namespace gpsd_client
+{
+
+/// Options controlling how gpsd reports are converted into ROS messages.
+struct ParserContext
+{
+  std::string frame_id;
+  bool use_gps_time;
+  bool check_fix_by_variance;
+};
+
+/// Converts gpsd's gps_data_t reports into ROS messages.
+///
+/// Implementations are specific to a range of gpsd API versions and are
+/// obtained through GpsdParserFactory. Each parser is named after the highest
+/// GPSD_API_MAJOR_VERSION it supports.
+class GpsdParser
+{
+public:
+  virtual ~GpsdParser() = default;
+
+  /// True if gpsd reports a device online for this report.
+  virtual bool isOnline(const gps_data_t& data) const = 0;
+
+  /// Convert a report into a GPSFix message stamped with @p stamp.
+  virtual gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
+                                            const rclcpp::Time& stamp) const = 0;
+
+  /// Convert a report into a NavSatFix message.
+  ///
+  /// The message is stamped with GPS time when the context enables
+  /// use_gps_time, otherwise with @p fallback_stamp. Returns std::nullopt when
+  /// the fix is rejected by the variance check and should not be published.
+  virtual std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(
+      const gps_data_t& data, const rclcpp::Time& fallback_stamp) const = 0;
+};
+
+}  // namespace gpsd_client
+
+#endif  // GPSD_CLIENT__GPSD_PARSER_HPP_

--- a/gpsd_client/include/gpsd_client/gpsd_parser.hpp
+++ b/gpsd_client/include/gpsd_client/gpsd_parser.hpp
@@ -50,7 +50,7 @@ public:
   /// The message is stamped with GPS time when the context enables
   /// use_gps_time, otherwise with @p fallback_stamp. Returns std::nullopt when
   /// the fix is rejected by the variance check and should not be published.
-  virtual std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(
+  [[nodiscard]] virtual std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(
       const gps_data_t& data, const rclcpp::Time& fallback_stamp) const = 0;
 };
 

--- a/gpsd_client/include/gpsd_client/gpsd_parser.hpp
+++ b/gpsd_client/include/gpsd_client/gpsd_parser.hpp
@@ -42,7 +42,7 @@ public:
   [[nodiscard]] virtual bool isOnline(const gps_data_t& data) const = 0;
 
   /// Convert a report into a GPSFix message stamped with @p stamp.
-  virtual gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
+  [[nodiscard]] virtual gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
                                             const rclcpp::Time& stamp) const = 0;
 
   /// Convert a report into a NavSatFix message.

--- a/gpsd_client/include/gpsd_client/gpsd_parser.hpp
+++ b/gpsd_client/include/gpsd_client/gpsd_parser.hpp
@@ -39,7 +39,7 @@ public:
   virtual ~GpsdParser() = default;
 
   /// True if gpsd reports a device online for this report.
-  virtual bool isOnline(const gps_data_t& data) const = 0;
+  [[nodiscard]] virtual bool isOnline(const gps_data_t& data) const = 0;
 
   /// Convert a report into a GPSFix message stamped with @p stamp.
   virtual gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,

--- a/gpsd_client/include/gpsd_client/gpsd_parser_factory.hpp
+++ b/gpsd_client/include/gpsd_client/gpsd_parser_factory.hpp
@@ -1,0 +1,27 @@
+#ifndef GPSD_CLIENT__GPSD_PARSER_FACTORY_HPP_
+#define GPSD_CLIENT__GPSD_PARSER_FACTORY_HPP_
+
+#include <memory>
+
+#include <gpsd_client/gpsd_parser.hpp>
+
+namespace gpsd_client
+{
+
+/// Produces the GpsdParser matching the gpsd API this package was built
+/// against.
+///
+/// Note: only one libgps is present at build time and the layout of
+/// gps_data_t is fixed by its header, so exactly one parser implementation
+/// can ever be compiled into a given binary. The factory therefore selects
+/// the parser with a compile-time ladder on GPSD_API_MAJOR_VERSION rather
+/// than a runtime registry.
+class GpsdParserFactory
+{
+public:
+  static std::unique_ptr<GpsdParser> create(const ParserContext& context);
+};
+
+}  // namespace gpsd_client
+
+#endif  // GPSD_CLIENT__GPSD_PARSER_FACTORY_HPP_

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
@@ -1,0 +1,56 @@
+#ifndef GPSD_CLIENT__PARSERS__GPSD_PARSER_BASE_HPP_
+#define GPSD_CLIENT__PARSERS__GPSD_PARSER_BASE_HPP_
+
+#include <cstdint>
+#include <optional>
+
+#include <gpsd_client/gpsd_parser.hpp>
+
+namespace gpsd_client
+{
+
+/// Shared parsing implementation for gpsd APIs 9 and newer.
+///
+/// Everything here uses only gps_data_t fields whose layout is identical
+/// across the supported API range (timespec online/fix.time, skyview[],
+/// gnssid, the dop struct, fix.eph). The only thing that moved between
+/// versions is where the fix status lives, which concrete parsers provide
+/// via getFixStatus().
+class GpsdParserBase : public GpsdParser
+{
+public:
+  explicit GpsdParserBase(const ParserContext& context)
+    : context_(context)
+  {
+  }
+
+  bool isOnline(const gps_data_t& data) const override;
+
+  gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
+                                    const rclcpp::Time& stamp) const override;
+
+  std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(
+      const gps_data_t& data, const rclcpp::Time& fallback_stamp) const override;
+
+protected:
+  /// Fix status (STATUS_*): gps_data_t::status in API 9, moved to
+  /// gps_data_t::fix.status in API 10.
+  virtual int getFixStatus(const gps_data_t& data) const = 0;
+
+private:
+  /// True if any satellite used in the solution is an SBAS satellite.
+  static bool usedSbas(const gps_data_t& data);
+
+  /// True if epx/epy/epv are all finite.
+  static bool hasValidVariance(const gps_data_t& data);
+
+  static int16_t mapGpsFixStatus(int gpsd_status, bool sbas_used);
+
+  static int8_t mapNavSatStatus(int gpsd_status, bool sbas_used);
+
+  ParserContext context_;
+};
+
+}  // namespace gpsd_client
+
+#endif  // GPSD_CLIENT__PARSERS__GPSD_PARSER_BASE_HPP_

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
@@ -24,7 +24,7 @@ public:
   {
   }
 
-  bool isOnline(const gps_data_t& data) const override;
+  [[nodiscard]] bool isOnline(const gps_data_t& data) const override;
 
   gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
                                     const rclcpp::Time& stamp) const override;

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
@@ -29,7 +29,7 @@ public:
   [[nodiscard]] gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
                                     const rclcpp::Time& stamp) const override;
 
-  std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(
+  [[nodiscard]] std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(
       const gps_data_t& data, const rclcpp::Time& fallback_stamp) const override;
 
 protected:

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
@@ -26,7 +26,7 @@ public:
 
   [[nodiscard]] bool isOnline(const gps_data_t& data) const override;
 
-  gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
+  [[nodiscard]] gps_msgs::msg::GPSFix parseGpsFix(const gps_data_t& data,
                                     const rclcpp::Time& stamp) const override;
 
   std::optional<sensor_msgs::msg::NavSatFix> parseNavSatFix(

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
@@ -35,7 +35,7 @@ public:
 protected:
   /// Fix status (STATUS_*): gps_data_t::status in API 9, moved to
   /// gps_data_t::fix.status in API 10.
-  virtual int getFixStatus(const gps_data_t& data) const = 0;
+  [[nodiscard]] virtual int getFixStatus(const gps_data_t& data) const = 0;
 
 private:
   /// True if any satellite used in the solution is an SBAS satellite.

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_base.hpp
@@ -19,8 +19,8 @@ namespace gpsd_client
 class GpsdParserBase : public GpsdParser
 {
 public:
-  explicit GpsdParserBase(const ParserContext& context)
-    : context_(context)
+  explicit GpsdParserBase(ParserContext context)
+    : context_(std::move(context))
   {
   }
 

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v16.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v16.hpp
@@ -20,7 +20,7 @@ public:
   using GpsdParserBase::GpsdParserBase;
 
 protected:
-  int getFixStatus(const gps_data_t& data) const override
+  [[nodiscard]] int getFixStatus(const gps_data_t& data) const override
   {
     return data.fix.status;
   }

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v16.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v16.hpp
@@ -1,0 +1,33 @@
+#ifndef GPSD_CLIENT__PARSERS__GPSD_PARSER_V16_HPP_
+#define GPSD_CLIENT__PARSERS__GPSD_PARSER_V16_HPP_
+
+#include <gps.h>
+
+// Supports gpsd APIs 10 through 16. Per project convention, parsers are named
+// after the highest API version they support: when a newer gpsd API is
+// verified compatible, extend this guard and rename the class accordingly.
+#if GPSD_API_MAJOR_VERSION >= 10
+
+#include <gpsd_client/parsers/gpsd_parser_base.hpp>
+
+namespace gpsd_client
+{
+
+/// Parser for gpsd API versions 10-16 (gpsd 3.21 - 3.27).
+class GpsdParserV16 : public GpsdParserBase
+{
+public:
+  using GpsdParserBase::GpsdParserBase;
+
+protected:
+  int getFixStatus(const gps_data_t& data) const override
+  {
+    return data.fix.status;
+  }
+};
+
+}  // namespace gpsd_client
+
+#endif  // GPSD_API_MAJOR_VERSION >= 10
+
+#endif  // GPSD_CLIENT__PARSERS__GPSD_PARSER_V16_HPP_

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v9.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v9.hpp
@@ -1,0 +1,32 @@
+#ifndef GPSD_CLIENT__PARSERS__GPSD_PARSER_V9_HPP_
+#define GPSD_CLIENT__PARSERS__GPSD_PARSER_V9_HPP_
+
+#include <gps.h>
+
+// This parser only compiles against gpsd API 9: it reads the fix status from
+// gps_data_t::status, which was removed (moved into gps_fix_t) in API 10.
+#if GPSD_API_MAJOR_VERSION == 9
+
+#include <gpsd_client/parsers/gpsd_parser_base.hpp>
+
+namespace gpsd_client
+{
+
+/// Parser for gpsd API version 9 (gpsd 3.20).
+class GpsdParserV9 : public GpsdParserBase
+{
+public:
+  using GpsdParserBase::GpsdParserBase;
+
+protected:
+  int getFixStatus(const gps_data_t& data) const override
+  {
+    return data.status;
+  }
+};
+
+}  // namespace gpsd_client
+
+#endif  // GPSD_API_MAJOR_VERSION == 9
+
+#endif  // GPSD_CLIENT__PARSERS__GPSD_PARSER_V9_HPP_

--- a/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v9.hpp
+++ b/gpsd_client/include/gpsd_client/parsers/gpsd_parser_v9.hpp
@@ -19,7 +19,7 @@ public:
   using GpsdParserBase::GpsdParserBase;
 
 protected:
-  int getFixStatus(const gps_data_t& data) const override
+  [[nodiscard]] int getFixStatus(const gps_data_t& data) const override
   {
     return data.status;
   }

--- a/gpsd_client/package.xml
+++ b/gpsd_client/package.xml
@@ -14,6 +14,7 @@
   <url type="website">http://ros.org/wiki/gpsd_client</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
 
   <depend>libgps</depend>
   <depend>gps_msgs</depend>

--- a/gpsd_client/package.xml
+++ b/gpsd_client/package.xml
@@ -22,6 +22,8 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/gpsd_client/src/client.cpp
+++ b/gpsd_client/src/client.cpp
@@ -1,12 +1,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <gps_msgs/msg/gps_fix.hpp>
-#include <gps_msgs/msg/gps_status.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
-#include <sensor_msgs/msg/nav_sat_status.hpp>
 #include <libgpsmm.h>
 
+#include <gpsd_client/gpsd_parser_factory.hpp>
+
 #include <chrono>
-#include <cmath>
+#include <memory>
+#include <string>
 
 using namespace std::chrono_literals;
 
@@ -55,6 +56,8 @@ namespace gpsd_client
 
       publish_period_ms = std::chrono::milliseconds{(int)(1000 / publish_rate_)};
 
+      parser_ = GpsdParserFactory::create({frame_id_, use_gps_time_, check_fix_by_variance_});
+
       std::string host = "localhost";
       int port = atoi(DEFAULT_GPSD_PORT);
       this->get_parameter_or("host", host, host);
@@ -63,22 +66,8 @@ namespace gpsd_client
       char port_s[12];
       snprintf(port_s, sizeof(port_s), "%d", port);
 
-      gps_data_t* resp = nullptr;
-
-#if GPSD_API_MAJOR_VERSION >= 5
-      gps_ = new gpsmm(host.c_str(), port_s);
-      resp = gps_->stream(WATCH_ENABLE);
-#elif GPSD_API_MAJOR_VERSION == 4
-      gps = new gpsmm();
-      gps->open(host.c_str(), port_s);
-      resp = gps->stream(WATCH_ENABLE);
-#else
-      gps = new gpsmm();
-      resp = gps->open(host.c_str(), port_s);
-      gps->query("w\n");
-#endif
-
-      if (resp == nullptr)
+      gps_ = std::make_unique<gpsmm>(host.c_str(), port_s);
+      if (gps_->stream(WATCH_ENABLE) == nullptr)
       {
         RCLCPP_ERROR(this->get_logger(), "Failed to open GPSd");
         return false;
@@ -90,341 +79,45 @@ namespace gpsd_client
 
     void step()
     {
-#if GPSD_API_MAJOR_VERSION >= 5
       if (!gps_->waiting(1e6))
         return;
 
       // Read out all queued data and only act on the latest
-      gps_data_t* p = NULL;
+      gps_data_t* p = nullptr;
       while (gps_->waiting(0))
       {
         p = gps_->read();
       }
 
-#else
-      gps_data_t *p = gps->poll();
-#endif
-      process_data(p);
-    }
-
-    void stop()
-    {
-      // gpsmm doesn't have a close method? OK ...
-    }
-
-  private:
-    void process_data(struct gps_data_t* p)
-    {
-      if (p == nullptr)
+      if (p == nullptr || !parser_->isOnline(*p))
         return;
 
-#if GPSD_API_MAJOR_VERSION >= 9
-      if (!p->online.tv_sec && !p->online.tv_nsec) {
-#else
-      if (!p->online) {
-#endif
-        return;
-      }
-
-      process_data_gps(p);
-      process_data_navsat(p);
-    }
-
-
-#if GPSD_API_MAJOR_VERSION >= 4
-#define SATS_VISIBLE p->satellites_visible
-#elif GPSD_API_MAJOR_VERSION == 3
-#define SATS_VISIBLE p->satellites
-#else
-#error "gpsd_client only supports gpsd API versions 3+"
-#endif
-
-    void process_data_gps(struct gps_data_t* p)
-    {
-      rclcpp::Time time = this->get_clock()->now();
-
-      gps_msgs::msg::GPSFix fix;
-      gps_msgs::msg::GPSStatus status;
-
-      status.header.stamp = time;
-      fix.header.stamp = time;
-      fix.header.frame_id = frame_id_;
-
-      status.satellites_used = p->satellites_used;
-
-#if GPSD_API_MAJOR_VERSION > 5
-      status.satellite_used_prn.clear();
-      status.satellite_used_prn.reserve(p->satellites_used);
-      for (int i = 0; i < p->satellites_visible; ++i)
-      {
-        if (p->skyview[i].used)
-        {
-          status.satellite_used_prn.push_back(p->skyview[i].PRN);
-        }
-      }
-#else
-      status.satellite_used_prn.resize(p->satellites_used);
-      for (int i = 0; i < p->satellites_used; ++i)
-      {
-        status.satellite_used_prn[i] = p->used[i];
-      }
-#endif
-
-      status.satellites_visible = SATS_VISIBLE;
-
-      status.satellite_visible_prn.resize(status.satellites_visible);
-      status.satellite_visible_z.resize(status.satellites_visible);
-      status.satellite_visible_azimuth.resize(status.satellites_visible);
-      status.satellite_visible_snr.resize(status.satellites_visible);
-
-      for (int i = 0; i < SATS_VISIBLE; ++i)
-      {
-#if GPSD_API_MAJOR_VERSION > 5
-        status.satellite_visible_prn[i] = p->skyview[i].PRN;
-        status.satellite_visible_z[i] = p->skyview[i].elevation;
-        status.satellite_visible_azimuth[i] = p->skyview[i].azimuth;
-        status.satellite_visible_snr[i] = p->skyview[i].ss;
-#else
-        status.satellite_visible_prn[i] = p->PRN[i];
-        status.satellite_visible_z[i] = p->elevation[i];
-        status.satellite_visible_azimuth[i] = p->azimuth[i];
-        status.satellite_visible_snr[i] = p->ss[i];
-#endif
-      }
-      const bool valid_variance =
-        std::isfinite(p->fix.epx) &&
-        std::isfinite(p->fix.epy) &&
-        std::isfinite(p->fix.epv);
-      if (((p->fix.mode == MODE_2D) || (p->fix.mode == MODE_3D)) && !(check_fix_by_variance_ && !valid_variance))
-      {
-        status.motion_source = gps_msgs::msg::GPSStatus::SOURCE_POINTS;
-        status.orientation_source = gps_msgs::msg::GPSStatus::SOURCE_POINTS;
-        status.position_source = gps_msgs::msg::GPSStatus::SOURCE_GPS;
-
-        status.status = 0; //gps_msgs::msg::GPSStatus::STATUS_FIX;
-
-        bool sbas_used = false;
-
-#if GPSD_API_MAJOR_VERSION >= 9
-        for (int i = 0; i < p->satellites_visible; ++i)
-        {
-          if (p->skyview[i].used)
-          {
-            if (p->skyview[i].gnssid == GNSSID_SBAS)
-              sbas_used = true;
-          }
-        }
-#endif
-
-#if GPSD_API_MAJOR_VERSION >= 10
-      switch (p->fix.status)
-#else
-      switch (p->status)
-#endif
-      {
-#if defined(STATUS_DGPS_FIX) || defined(STATUS_DGPS)
-#ifdef STATUS_DGPS_FIX
-        case STATUS_DGPS_FIX:
-#else
-        case STATUS_DGPS:
-#endif
-          if (sbas_used)
-            status.status = 1; //gps_msgs::msg::GPSStatus::STATUS_SBAS_FIX;
-          else
-            status.status = 18; //gps_msgs::msg::GPSStatus::STATUS_DGPS_FIX;
-          break;
-#endif
-#ifdef STATUS_RTK_FIX
-        case STATUS_RTK_FIX:
-          status.status = 19; //gps_msgs::msg::GPSStatus::STATUS_RTK_FIX;
-          break;
-#endif
-#ifdef STATUS_RTK_FLT
-        case STATUS_RTK_FLT:
-          status.status = 20; //gps_msgs::msg::GPSStatus::STATUS_RTK_FLOAT;
-          break;
-#endif
-        default:
-          break;
-      }
-
-#if GPSD_API_MAJOR_VERSION >= 9
-        fix.time = (double)(p->fix.time.tv_sec) + ((double)(p->fix.time.tv_nsec)) / 1e9;
-#else
-        fix.time = p->fix.time;
-#endif
-        fix.latitude = p->fix.latitude;
-        fix.longitude = p->fix.longitude;
-        if (p->fix.mode == MODE_3D)
-        {
-          fix.altitude = p->fix.altitude;
-        }
-        else
-        {
-          fix.altitude = std::nan("");
-        }
-        fix.track = p->fix.track;
-        fix.speed = p->fix.speed;
-        fix.climb = p->fix.climb;
-
-#if GPSD_API_MAJOR_VERSION > 3
-        fix.pdop = p->dop.pdop;
-        fix.hdop = p->dop.hdop;
-        fix.vdop = p->dop.vdop;
-        fix.tdop = p->dop.tdop;
-        fix.gdop = p->dop.gdop;
-#else
-        fix.pdop = p->pdop;
-        fix.hdop = p->hdop;
-        fix.vdop = p->vdop;
-        fix.tdop = p->tdop;
-        fix.gdop = p->gdop;
-#endif
-
-#if GPSD_API_MAJOR_VERSION < 8
-        fix.err = p->epe;
-#else
-        fix.err = p->fix.eph;
-#endif
-        fix.err_vert = p->fix.epv;
-        fix.err_track = p->fix.epd;
-        fix.err_speed = p->fix.eps;
-        fix.err_climb = p->fix.epc;
-        fix.err_time = p->fix.ept;
-
-        /* TODO: attitude */
-      } else {
-        status.status = -1; //gps_msgs::msg::GPSStatus::STATUS_NO_FIX;
-      }
-
-      fix.status = status;
+      rclcpp::Time now = this->get_clock()->now();
 
       RCLCPP_DEBUG(this->get_logger(), "Publishing gps fix...");
-      gps_fix_pub_->publish(fix);
-    }
+      gps_fix_pub_->publish(parser_->parseGpsFix(*p, now));
 
-    void process_data_navsat(struct gps_data_t* p)
-    {
-      sensor_msgs::msg::NavSatFix::UniquePtr fix = std::make_unique<sensor_msgs::msg::NavSatFix>();
-
-      /* TODO: Support SBAS and other GBAS. */
-
-#if GPSD_API_MAJOR_VERSION >= 9
-      if (use_gps_time_ && (p->online.tv_sec || p->online.tv_nsec)) {
-        fix->header.stamp = rclcpp::Time(p->fix.time.tv_sec, p->fix.time.tv_nsec);
-#else
-      if (use_gps_time_ && std::isfinite(p->fix.time)) {
-        fix->header.stamp = rclcpp::Time(p->fix.time);
-#endif
-      }
-      else {
-        fix->header.stamp = this->get_clock()->now();
-      }
-
-      fix->header.frame_id = frame_id_;
-
-      bool sbas_used = false;
-
-#if GPSD_API_MAJOR_VERSION > 5
-      fix->status.service = sensor_msgs::msg::NavSatStatus::SERVICE_UNKNOWN;
-      for (int i = 0; i < p->satellites_visible; ++i)
+      std::optional<sensor_msgs::msg::NavSatFix> navsat_fix = parser_->parseNavSatFix(*p, now);
+      if (navsat_fix.has_value())
       {
-        if (p->skyview[i].used)
-        {
-          if (p->skyview[i].gnssid == GNSSID_GPS)
-            fix->status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GPS;
-          else if (p->skyview[i].gnssid == GNSSID_GLO)
-            fix->status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GLONASS;
-          else if (p->skyview[i].gnssid == GNSSID_BD)
-            fix->status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_COMPASS;
-          else if (p->skyview[i].gnssid == GNSSID_GAL)
-            fix->status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GALILEO;
-          if (p->skyview[i].gnssid == GNSSID_SBAS)
-            sbas_used = true;
-        }
-      }
-#else
-      fix->status.service = sensor_msgs::msg::NavSatStatus::SERVICE_GPS;
-#endif
-
-      if (p->fix.mode == MODE_2D || p->fix.mode == MODE_3D)
-      {
-        fix->status.status = 0; //sensor_msgs::msg::NavSatStatus::STATUS_FIX;
-        /* gpsmm pollutes the global namespace with STATUS_,
-         * so we need to use the ROS message's integer values
-         * for status.status
-         */
-#if GPSD_API_MAJOR_VERSION >= 10
-        switch (p->fix.status)
-#else
-        switch (p->status)
-#endif
-        {
-#if defined(STATUS_DGPS_FIX) || defined(STATUS_DGPS)
-#ifdef STATUS_DGPS_FIX
-          case STATUS_DGPS_FIX:
-#else
-          case STATUS_DGPS:
-#endif
-            if (sbas_used)
-              fix->status.status = 1; //sensor_msgs::msg::NavSatStatus::STATUS_SBAS_FIX;
-            else
-              fix->status.status = 2; //sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX;
-            break;
-#endif
-#ifdef STATUS_RTK_FIX
-          case STATUS_RTK_FIX:
-            fix->status.status = 2; //sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX;
-            break;
-#endif
-#ifdef STATUS_RTK_FLT
-          case STATUS_RTK_FLT:
-            fix->status.status = 2; //sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX;
-            break;
-#endif
-          default:
-            break;
-        }
+        RCLCPP_DEBUG(this->get_logger(), "Publishing navsatfix...");
+        navsatfix_pub_->publish(*navsat_fix);
       }
       else
-      {
-        fix->status.status = -1; //sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX;
-      }
-
-      fix->latitude = p->fix.latitude;
-      fix->longitude = p->fix.longitude;
-      fix->altitude = p->fix.altitude;
-
-      /* gpsd reports status=OK even when there is no current fix,
-       * as long as there has been a fix previously. Throw out these
-       * fake results, which have NaN variance
-       */
-      if (check_fix_by_variance_ &&
-          (!std::isfinite(p->fix.epx) ||
-           !std::isfinite(p->fix.epy) ||
-           !std::isfinite(p->fix.epv)))
       {
         RCLCPP_DEBUG_THROTTLE(this->get_logger(),
           *this->get_clock(),
           1000,
           "GPS status was reported as OK, but variance was invalid");
-        return;
       }
-
-      fix->position_covariance[0] = p->fix.epx;
-      fix->position_covariance[4] = p->fix.epy;
-      fix->position_covariance[8] = p->fix.epv;
-
-      fix->position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
-
-      RCLCPP_DEBUG(this->get_logger(), "Publishing navsatfix...");
-      navsatfix_pub_->publish(std::move(fix));
     }
 
+  private:
     rclcpp::Publisher<gps_msgs::msg::GPSFix>::SharedPtr gps_fix_pub_;
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_pub_;
 
-    gpsmm* gps_;
+    std::unique_ptr<gpsmm> gps_;
+    std::unique_ptr<GpsdParser> parser_;
 
     bool use_gps_time_;
     bool check_fix_by_variance_;

--- a/gpsd_client/src/gpsd_parser_factory.cpp
+++ b/gpsd_client/src/gpsd_parser_factory.cpp
@@ -1,0 +1,26 @@
+#include <gpsd_client/gpsd_parser_factory.hpp>
+
+#include <gpsd_client/parsers/gpsd_parser_v9.hpp>
+#include <gpsd_client/parsers/gpsd_parser_v16.hpp>
+
+namespace gpsd_client
+{
+
+std::unique_ptr<GpsdParser> GpsdParserFactory::create(const ParserContext& context)
+{
+  // The one and only version-selection ladder. See the class comment in
+  // gpsd_parser_factory.hpp for why this is compile-time rather than runtime.
+#if GPSD_API_MAJOR_VERSION == 9
+  return std::make_unique<GpsdParserV9>(context);
+#elif GPSD_API_MAJOR_VERSION <= 16
+  return std::make_unique<GpsdParserV16>(context);
+#else
+  // Newer than tested: warn at compile time and use the newest parser. Once
+  // verified compatible, extend the guard in gpsd_parser_v16.hpp and rename
+  // the parser after the new highest supported version.
+#warning "Untested GPSD_API_MAJOR_VERSION > 16; falling back to GpsdParserV16"
+  return std::make_unique<GpsdParserV16>(context);
+#endif
+}
+
+}  // namespace gpsd_client

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -139,7 +139,7 @@ gps_msgs::msg::GPSFix GpsdParserBase::parseGpsFix(const gps_data_t& data,
   }
 
   if (((data.fix.mode == MODE_2D) || (data.fix.mode == MODE_3D)) &&
-      !(context_.check_fix_by_variance && !hasValidVariance(data)))
+      (!context_.check_fix_by_variance || hasValidVariance(data)))
   {
     status.motion_source = gps_msgs::msg::GPSStatus::SOURCE_POINTS;
     status.orientation_source = gps_msgs::msg::GPSStatus::SOURCE_POINTS;

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -255,6 +255,7 @@ std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
     return std::nullopt;
   }
 
+  // Covariance is a 3x3 matrix, and this sets the diagonal elements based on the reported variances.
   fix.position_covariance[0] = data.fix.epx;
   fix.position_covariance[4] = data.fix.epy;
   fix.position_covariance[8] = data.fix.epv;

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -1,0 +1,249 @@
+#include <gpsd_client/parsers/gpsd_parser_base.hpp>
+
+#include <cmath>
+
+#include <gps_msgs/msg/gps_status.hpp>
+#include <sensor_msgs/msg/nav_sat_status.hpp>
+
+namespace gpsd_client
+{
+
+bool GpsdParserBase::isOnline(const gps_data_t& data) const
+{
+  return data.online.tv_sec || data.online.tv_nsec;
+}
+
+bool GpsdParserBase::usedSbas(const gps_data_t& data)
+{
+  for (int i = 0; i < data.satellites_visible; ++i)
+  {
+    if (data.skyview[i].used && data.skyview[i].gnssid == GNSSID_SBAS)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool GpsdParserBase::hasValidVariance(const gps_data_t& data)
+{
+  return std::isfinite(data.fix.epx) &&
+         std::isfinite(data.fix.epy) &&
+         std::isfinite(data.fix.epv);
+}
+
+/* gpsmm pollutes the global namespace with STATUS_, so we need to use the
+ * ROS messages' integer values for status.status in the mapping helpers
+ * below. The #ifdef blocks are feature detection: gpsd renamed these macros
+ * over the years (e.g. STATUS_DGPS_FIX became STATUS_DGPS).
+ */
+
+int16_t GpsdParserBase::mapGpsFixStatus(int gpsd_status, bool sbas_used)
+{
+  switch (gpsd_status)
+  {
+#if defined(STATUS_DGPS_FIX) || defined(STATUS_DGPS)
+#ifdef STATUS_DGPS_FIX
+    case STATUS_DGPS_FIX:
+#else
+    case STATUS_DGPS:
+#endif
+      if (sbas_used)
+        return 1;  // gps_msgs::msg::GPSStatus::STATUS_SBAS_FIX
+      else
+        return 18; // gps_msgs::msg::GPSStatus::STATUS_DGPS_FIX
+#endif
+#ifdef STATUS_RTK_FIX
+    case STATUS_RTK_FIX:
+      return 19;   // gps_msgs::msg::GPSStatus::STATUS_RTK_FIX
+#endif
+#ifdef STATUS_RTK_FLT
+    case STATUS_RTK_FLT:
+      return 20;   // gps_msgs::msg::GPSStatus::STATUS_RTK_FLOAT
+#endif
+    default:
+      return 0;    // gps_msgs::msg::GPSStatus::STATUS_FIX
+  }
+}
+
+int8_t GpsdParserBase::mapNavSatStatus(int gpsd_status, bool sbas_used)
+{
+  switch (gpsd_status)
+  {
+#if defined(STATUS_DGPS_FIX) || defined(STATUS_DGPS)
+#ifdef STATUS_DGPS_FIX
+    case STATUS_DGPS_FIX:
+#else
+    case STATUS_DGPS:
+#endif
+      if (sbas_used)
+        return 1;  // sensor_msgs::msg::NavSatStatus::STATUS_SBAS_FIX
+      else
+        return 2;  // sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX
+#endif
+#ifdef STATUS_RTK_FIX
+    case STATUS_RTK_FIX:
+      return 2;    // sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX
+#endif
+#ifdef STATUS_RTK_FLT
+    case STATUS_RTK_FLT:
+      return 2;    // sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX
+#endif
+    default:
+      return 0;    // sensor_msgs::msg::NavSatStatus::STATUS_FIX
+  }
+}
+
+gps_msgs::msg::GPSFix GpsdParserBase::parseGpsFix(const gps_data_t& data,
+                                                  const rclcpp::Time& stamp) const
+{
+  gps_msgs::msg::GPSFix fix;
+  gps_msgs::msg::GPSStatus status;
+
+  status.header.stamp = stamp;
+  fix.header.stamp = stamp;
+  fix.header.frame_id = context_.frame_id;
+
+  status.satellites_used = data.satellites_used;
+
+  status.satellite_used_prn.reserve(data.satellites_used);
+  for (int i = 0; i < data.satellites_visible; ++i)
+  {
+    if (data.skyview[i].used)
+    {
+      status.satellite_used_prn.push_back(data.skyview[i].PRN);
+    }
+  }
+
+  status.satellites_visible = data.satellites_visible;
+
+  status.satellite_visible_prn.resize(status.satellites_visible);
+  status.satellite_visible_z.resize(status.satellites_visible);
+  status.satellite_visible_azimuth.resize(status.satellites_visible);
+  status.satellite_visible_snr.resize(status.satellites_visible);
+
+  for (int i = 0; i < data.satellites_visible; ++i)
+  {
+    status.satellite_visible_prn[i] = data.skyview[i].PRN;
+    status.satellite_visible_z[i] = data.skyview[i].elevation;
+    status.satellite_visible_azimuth[i] = data.skyview[i].azimuth;
+    status.satellite_visible_snr[i] = data.skyview[i].ss;
+  }
+
+  if (((data.fix.mode == MODE_2D) || (data.fix.mode == MODE_3D)) &&
+      !(context_.check_fix_by_variance && !hasValidVariance(data)))
+  {
+    status.motion_source = gps_msgs::msg::GPSStatus::SOURCE_POINTS;
+    status.orientation_source = gps_msgs::msg::GPSStatus::SOURCE_POINTS;
+    status.position_source = gps_msgs::msg::GPSStatus::SOURCE_GPS;
+
+    status.status = mapGpsFixStatus(getFixStatus(data), usedSbas(data));
+
+    fix.time = (double)(data.fix.time.tv_sec) +
+               ((double)(data.fix.time.tv_nsec)) / 1e9;
+    fix.latitude = data.fix.latitude;
+    fix.longitude = data.fix.longitude;
+    if (data.fix.mode == MODE_3D)
+    {
+      fix.altitude = data.fix.altitude;
+    }
+    else
+    {
+      fix.altitude = std::nan("");
+    }
+    fix.track = data.fix.track;
+    fix.speed = data.fix.speed;
+    fix.climb = data.fix.climb;
+
+    fix.pdop = data.dop.pdop;
+    fix.hdop = data.dop.hdop;
+    fix.vdop = data.dop.vdop;
+    fix.tdop = data.dop.tdop;
+    fix.gdop = data.dop.gdop;
+
+    fix.err = data.fix.eph;
+    fix.err_vert = data.fix.epv;
+    fix.err_track = data.fix.epd;
+    fix.err_speed = data.fix.eps;
+    fix.err_climb = data.fix.epc;
+    fix.err_time = data.fix.ept;
+
+    /* TODO: attitude */
+  }
+  else
+  {
+    status.status = -1; // gps_msgs::msg::GPSStatus::STATUS_NO_FIX
+  }
+
+  fix.status = status;
+
+  return fix;
+}
+
+std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
+    const gps_data_t& data, const rclcpp::Time& fallback_stamp) const
+{
+  sensor_msgs::msg::NavSatFix fix;
+
+  /* TODO: Support SBAS and other GBAS. */
+
+  if (context_.use_gps_time && (data.online.tv_sec || data.online.tv_nsec))
+  {
+    fix.header.stamp = rclcpp::Time(data.fix.time.tv_sec, data.fix.time.tv_nsec);
+  }
+  else
+  {
+    fix.header.stamp = fallback_stamp;
+  }
+
+  fix.header.frame_id = context_.frame_id;
+
+  fix.status.service = sensor_msgs::msg::NavSatStatus::SERVICE_UNKNOWN;
+  for (int i = 0; i < data.satellites_visible; ++i)
+  {
+    if (data.skyview[i].used)
+    {
+      if (data.skyview[i].gnssid == GNSSID_GPS)
+        fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GPS;
+      else if (data.skyview[i].gnssid == GNSSID_GLO)
+        fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GLONASS;
+      else if (data.skyview[i].gnssid == GNSSID_BD)
+        fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_COMPASS;
+      else if (data.skyview[i].gnssid == GNSSID_GAL)
+        fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GALILEO;
+    }
+  }
+
+  if (data.fix.mode == MODE_2D || data.fix.mode == MODE_3D)
+  {
+    fix.status.status = mapNavSatStatus(getFixStatus(data), usedSbas(data));
+  }
+  else
+  {
+    fix.status.status = -1; // sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX
+  }
+
+  fix.latitude = data.fix.latitude;
+  fix.longitude = data.fix.longitude;
+  fix.altitude = data.fix.altitude;
+
+  /* gpsd reports status=OK even when there is no current fix, as long as
+   * there has been a fix previously. Throw out these fake results, which
+   * have NaN variance.
+   */
+  if (context_.check_fix_by_variance && !hasValidVariance(data))
+  {
+    return std::nullopt;
+  }
+
+  fix.position_covariance[0] = data.fix.epx;
+  fix.position_covariance[4] = data.fix.epy;
+  fix.position_covariance[8] = data.fix.epv;
+
+  fix.position_covariance_type =
+      sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+
+  return fix;
+}
+
+}  // namespace gpsd_client

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -210,7 +210,7 @@ std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
   fix.header.frame_id = context_.frame_id;
 
 #ifdef NO_UNKNOWN_FIX
-  fix.status.service = 0;
+  fix.status.service = 0; // Initialize to 0 before setting bits
 #else
   fix.status.service = sensor_msgs::msg::NavSatStatus::SERVICE_UNKNOWN;
 #endif

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -209,7 +209,11 @@ std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
 
   fix.header.frame_id = context_.frame_id;
 
+#ifdef NO_UNKNOWN_FIX
+  fix.status.service = 0;
+#else
   fix.status.service = sensor_msgs::msg::NavSatStatus::SERVICE_UNKNOWN;
+#endif
   for (int i = 0; i < data.satellites_visible; ++i)
   {
     if (data.skyview[i].used)

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -7,6 +7,7 @@
 
 namespace gpsd_client
 {
+constexpr uint32_t NANOSECONDS_IN_SECOND = 1e9;
 
 bool GpsdParserBase::isOnline(const gps_data_t& data) const
 {
@@ -147,8 +148,8 @@ gps_msgs::msg::GPSFix GpsdParserBase::parseGpsFix(const gps_data_t& data,
 
     status.status = mapGpsFixStatus(getFixStatus(data), usedSbas(data));
 
-    fix.time = (double)(data.fix.time.tv_sec) +
-               ((double)(data.fix.time.tv_nsec)) / 1e9;
+    fix.time = static_cast<double>(data.fix.time.tv_sec) +
+               (static_cast<double>(data.fix.time.tv_nsec) / NANOSECONDS_IN_SECOND);
     fix.latitude = data.fix.latitude;
     fix.longitude = data.fix.longitude;
     if (data.fix.mode == MODE_3D)

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -49,9 +49,13 @@ int16_t GpsdParserBase::mapGpsFixStatus(int gpsd_status, bool sbas_used)
     case STATUS_DGPS:
 #endif
       if (sbas_used)
+      {
         return 1;  // gps_msgs::msg::GPSStatus::STATUS_SBAS_FIX
+      }
       else
+      {
         return 18; // gps_msgs::msg::GPSStatus::STATUS_DGPS_FIX
+      }
 #endif
 #ifdef STATUS_RTK_FIX
     case STATUS_RTK_FIX:
@@ -77,9 +81,13 @@ int8_t GpsdParserBase::mapNavSatStatus(int gpsd_status, bool sbas_used)
     case STATUS_DGPS:
 #endif
       if (sbas_used)
+      {
         return 1;  // sensor_msgs::msg::NavSatStatus::STATUS_SBAS_FIX
+      }
       else
+      {
         return 2;  // sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX
+      }
 #endif
 #ifdef STATUS_RTK_FIX
     case STATUS_RTK_FIX:
@@ -204,13 +212,21 @@ std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
     if (data.skyview[i].used)
     {
       if (data.skyview[i].gnssid == GNSSID_GPS)
+      {
         fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GPS;
+      }
       else if (data.skyview[i].gnssid == GNSSID_GLO)
+      {
         fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GLONASS;
+      }
       else if (data.skyview[i].gnssid == GNSSID_BD)
+      {
         fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_COMPASS;
+      }
       else if (data.skyview[i].gnssid == GNSSID_GAL)
+      {
         fix.status.service |= sensor_msgs::msg::NavSatStatus::SERVICE_GALILEO;
+      }
     }
   }
 

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -10,7 +10,7 @@ namespace gpsd_client
 
 bool GpsdParserBase::isOnline(const gps_data_t& data) const
 {
-  return data.online.tv_sec || data.online.tv_nsec;
+  return ((data.online.tv_sec > 0) || (data.online.tv_nsec > 0));
 }
 
 bool GpsdParserBase::usedSbas(const gps_data_t& data)

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -198,7 +198,9 @@ std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
 
   if (context_.use_gps_time && ((data.online.tv_sec > 0) || (data.online.tv_nsec > 0)))
   {
-    fix.header.stamp = rclcpp::Time(data.fix.time.tv_sec, data.fix.time.tv_nsec);
+    fix.header.stamp = rclcpp::Time(
+      static_cast<uint32_t>(data.fix.time.tv_sec),
+      static_cast<uint32_t>(data.fix.time.tv_nsec));
   }
   else
   {

--- a/gpsd_client/src/parsers/gpsd_parser_base.cpp
+++ b/gpsd_client/src/parsers/gpsd_parser_base.cpp
@@ -195,7 +195,7 @@ std::optional<sensor_msgs::msg::NavSatFix> GpsdParserBase::parseNavSatFix(
 
   /* TODO: Support SBAS and other GBAS. */
 
-  if (context_.use_gps_time && (data.online.tv_sec || data.online.tv_nsec))
+  if (context_.use_gps_time && ((data.online.tv_sec > 0) || (data.online.tv_nsec > 0)))
   {
     fix.header.stamp = rclcpp::Time(data.fix.time.tv_sec, data.fix.time.tv_nsec);
   }

--- a/gpsd_client/test/test_gpsd_parser.cpp
+++ b/gpsd_client/test/test_gpsd_parser.cpp
@@ -28,6 +28,19 @@ constexpr int kStatusDgps = STATUS_DGPS_FIX;
 constexpr int kStatusDgps = STATUS_DGPS;
 #endif
 
+// A plain GPS fix: STATUS_FIX until gpsd renamed it to STATUS_GPS.
+#ifdef STATUS_GPS
+constexpr int kStatusGps = STATUS_GPS;
+#else
+constexpr int kStatusGps = STATUS_FIX;
+#endif
+
+/* gps.h defines STATUS_* macros whose names collide with the ROS message
+ * constants (e.g. STATUS_FIX in gpsd < 3.23), so the expectations below use
+ * the messages' integer values with the symbolic name in a comment -- the
+ * same convention the parser sources use.
+ */
+
 gpsd_client::ParserContext makeContext()
 {
   gpsd_client::ParserContext context;
@@ -44,7 +57,7 @@ gps_data_t makeThreeDFix()
 
   data.online.tv_sec = 100;
   data.fix.mode = MODE_3D;
-  setFixStatus(data, STATUS_GPS);
+  setFixStatus(data, kStatusGps);
 
   data.fix.time.tv_sec = 1700000000;
   data.fix.time.tv_nsec = 500000000;
@@ -136,7 +149,7 @@ TEST(GpsdParser, ThreeDFixPopulatesGpsFix)
   EXPECT_DOUBLE_EQ(fix.err_climb, 1.25);
   EXPECT_DOUBLE_EQ(fix.err_time, 0.005);
 
-  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_FIX);
+  EXPECT_EQ(fix.status.status, 0 /* GPSStatus::STATUS_FIX */);
   EXPECT_EQ(fix.status.satellites_used, 2);
   ASSERT_EQ(fix.status.satellite_used_prn.size(), 2u);
   EXPECT_EQ(fix.status.satellite_used_prn[0], 10);
@@ -158,7 +171,7 @@ TEST(GpsdParser, ThreeDFixPopulatesNavSatFix)
 
   ASSERT_TRUE(fix.has_value());
   EXPECT_EQ(fix->header.frame_id, "gps");
-  EXPECT_EQ(fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_FIX);
+  EXPECT_EQ(fix->status.status, 0 /* NavSatStatus::STATUS_FIX */);
   EXPECT_EQ(fix->status.service, sensor_msgs::msg::NavSatStatus::SERVICE_GPS);
   EXPECT_DOUBLE_EQ(fix->latitude, 29.44);
   EXPECT_DOUBLE_EQ(fix->longitude, -98.61);
@@ -178,7 +191,7 @@ TEST(GpsdParser, TwoDFixHasNanAltitude)
 
   gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
 
-  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_FIX);
+  EXPECT_EQ(fix.status.status, 0 /* GPSStatus::STATUS_FIX */);
   EXPECT_DOUBLE_EQ(fix.latitude, 29.44);
   EXPECT_TRUE(std::isnan(fix.altitude));
 }
@@ -190,13 +203,13 @@ TEST(GpsdParser, NoFixSetsNoFixStatus)
   data.fix.mode = MODE_NO_FIX;
 
   gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
-  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_NO_FIX);
+  EXPECT_EQ(fix.status.status, -1 /* GPSStatus::STATUS_NO_FIX */);
   // Position fields are only filled in when there is a fix.
   EXPECT_DOUBLE_EQ(fix.latitude, 0.0);
 
   auto navsat_fix = parser->parseNavSatFix(data, rclcpp::Time(42, 0));
   ASSERT_TRUE(navsat_fix.has_value());  // variance check is off
-  EXPECT_EQ(navsat_fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX);
+  EXPECT_EQ(navsat_fix->status.status, -1 /* NavSatStatus::STATUS_NO_FIX */);
 }
 
 TEST(GpsdParser, InvalidVarianceRejectsNavSatFixOnly)
@@ -213,7 +226,7 @@ TEST(GpsdParser, InvalidVarianceRejectsNavSatFixOnly)
 
   // ... while the GPSFix is still produced, downgraded to NO_FIX.
   gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
-  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_NO_FIX);
+  EXPECT_EQ(fix.status.status, -1 /* GPSStatus::STATUS_NO_FIX */);
 }
 
 TEST(GpsdParser, ServiceBitmaskAndSbasStatus)
@@ -231,10 +244,10 @@ TEST(GpsdParser, ServiceBitmaskAndSbasStatus)
   EXPECT_EQ(navsat_fix->status.service,
             sensor_msgs::msg::NavSatStatus::SERVICE_GPS |
             sensor_msgs::msg::NavSatStatus::SERVICE_GLONASS);
-  EXPECT_EQ(navsat_fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_SBAS_FIX);
+  EXPECT_EQ(navsat_fix->status.status, 1 /* NavSatStatus::STATUS_SBAS_FIX */);
 
   gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
-  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_SBAS_FIX);
+  EXPECT_EQ(fix.status.status, 1 /* GPSStatus::STATUS_SBAS_FIX */);
 }
 
 TEST(GpsdParser, DgpsStatusWithoutSbas)
@@ -244,11 +257,11 @@ TEST(GpsdParser, DgpsStatusWithoutSbas)
   setFixStatus(data, kStatusDgps);
 
   gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
-  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_DGPS_FIX);
+  EXPECT_EQ(fix.status.status, 18 /* GPSStatus::STATUS_DGPS_FIX */);
 
   auto navsat_fix = parser->parseNavSatFix(data, rclcpp::Time(42, 0));
   ASSERT_TRUE(navsat_fix.has_value());
-  EXPECT_EQ(navsat_fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX);
+  EXPECT_EQ(navsat_fix->status.status, 2 /* NavSatStatus::STATUS_GBAS_FIX */);
 }
 
 TEST(GpsdParser, NavSatFixStampUsesGpsTimeWhenEnabled)

--- a/gpsd_client/test/test_gpsd_parser.cpp
+++ b/gpsd_client/test/test_gpsd_parser.cpp
@@ -1,0 +1,275 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+
+#include <gpsd_client/gpsd_parser_factory.hpp>
+
+namespace
+{
+
+// The tests, like the parsers, can only compile against the single installed
+// libgps header, so they exercise whichever parser the factory selects for
+// GPSD_API_MAJOR_VERSION. The two version-dependent details below (where the
+// fix status lives and what the DGPS status macro is called) are isolated
+// here.
+void setFixStatus(gps_data_t& data, int status)
+{
+#if GPSD_API_MAJOR_VERSION >= 10
+  data.fix.status = status;
+#else
+  data.status = status;
+#endif
+}
+
+#ifdef STATUS_DGPS_FIX
+constexpr int kStatusDgps = STATUS_DGPS_FIX;
+#else
+constexpr int kStatusDgps = STATUS_DGPS;
+#endif
+
+gpsd_client::ParserContext makeContext()
+{
+  gpsd_client::ParserContext context;
+  context.frame_id = "gps";
+  context.use_gps_time = false;
+  context.check_fix_by_variance = false;
+  return context;
+}
+
+// A plausible online 3D fix with two used GPS satellites.
+gps_data_t makeThreeDFix()
+{
+  gps_data_t data{};
+
+  data.online.tv_sec = 100;
+  data.fix.mode = MODE_3D;
+  setFixStatus(data, STATUS_GPS);
+
+  data.fix.time.tv_sec = 1700000000;
+  data.fix.time.tv_nsec = 500000000;
+
+  data.fix.latitude = 29.44;
+  data.fix.longitude = -98.61;
+  data.fix.altitude = 250.0;
+  data.fix.track = 90.0;
+  data.fix.speed = 2.5;
+  data.fix.climb = 0.25;
+
+  data.fix.epx = 1.5;
+  data.fix.epy = 2.5;
+  data.fix.epv = 3.5;
+  data.fix.epd = 0.5;
+  data.fix.eps = 0.75;
+  data.fix.epc = 1.25;
+  data.fix.ept = 0.005;
+  data.fix.eph = 4.5;
+
+  data.dop.pdop = 1.1;
+  data.dop.hdop = 1.2;
+  data.dop.vdop = 1.3;
+  data.dop.tdop = 1.4;
+  data.dop.gdop = 1.5;
+
+  data.satellites_used = 2;
+  data.satellites_visible = 3;
+  for (int i = 0; i < 3; ++i)
+  {
+    data.skyview[i].PRN = 10 + i;
+    data.skyview[i].elevation = 30 + i;
+    data.skyview[i].azimuth = 100 + i;
+    data.skyview[i].ss = 40 + i;
+    data.skyview[i].gnssid = GNSSID_GPS;
+    data.skyview[i].used = i < 2;
+  }
+
+  return data;
+}
+
+std::unique_ptr<gpsd_client::GpsdParser> makeParser(
+    const gpsd_client::ParserContext& context = makeContext())
+{
+  return gpsd_client::GpsdParserFactory::create(context);
+}
+
+}  // namespace
+
+TEST(GpsdParser, ReportsOnline)
+{
+  auto parser = makeParser();
+
+  gps_data_t data{};
+  EXPECT_FALSE(parser->isOnline(data));
+
+  data.online.tv_sec = 100;
+  EXPECT_TRUE(parser->isOnline(data));
+}
+
+TEST(GpsdParser, ThreeDFixPopulatesGpsFix)
+{
+  auto parser = makeParser();
+  gps_data_t data = makeThreeDFix();
+
+  gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
+
+  EXPECT_EQ(fix.header.frame_id, "gps");
+  EXPECT_EQ(fix.header.stamp.sec, 42);
+
+  EXPECT_DOUBLE_EQ(fix.latitude, 29.44);
+  EXPECT_DOUBLE_EQ(fix.longitude, -98.61);
+  EXPECT_DOUBLE_EQ(fix.altitude, 250.0);
+  EXPECT_DOUBLE_EQ(fix.track, 90.0);
+  EXPECT_DOUBLE_EQ(fix.speed, 2.5);
+  EXPECT_DOUBLE_EQ(fix.climb, 0.25);
+  EXPECT_DOUBLE_EQ(fix.time, 1700000000.5);
+
+  EXPECT_DOUBLE_EQ(fix.pdop, 1.1);
+  EXPECT_DOUBLE_EQ(fix.hdop, 1.2);
+  EXPECT_DOUBLE_EQ(fix.vdop, 1.3);
+  EXPECT_DOUBLE_EQ(fix.tdop, 1.4);
+  EXPECT_DOUBLE_EQ(fix.gdop, 1.5);
+
+  EXPECT_DOUBLE_EQ(fix.err, 4.5);
+  EXPECT_DOUBLE_EQ(fix.err_vert, 3.5);
+  EXPECT_DOUBLE_EQ(fix.err_track, 0.5);
+  EXPECT_DOUBLE_EQ(fix.err_speed, 0.75);
+  EXPECT_DOUBLE_EQ(fix.err_climb, 1.25);
+  EXPECT_DOUBLE_EQ(fix.err_time, 0.005);
+
+  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_FIX);
+  EXPECT_EQ(fix.status.satellites_used, 2);
+  ASSERT_EQ(fix.status.satellite_used_prn.size(), 2u);
+  EXPECT_EQ(fix.status.satellite_used_prn[0], 10);
+  EXPECT_EQ(fix.status.satellite_used_prn[1], 11);
+  EXPECT_EQ(fix.status.satellites_visible, 3);
+  ASSERT_EQ(fix.status.satellite_visible_prn.size(), 3u);
+  EXPECT_EQ(fix.status.satellite_visible_prn[2], 12);
+  EXPECT_EQ(fix.status.satellite_visible_z[2], 32);
+  EXPECT_EQ(fix.status.satellite_visible_azimuth[2], 102);
+  EXPECT_EQ(fix.status.satellite_visible_snr[2], 42);
+}
+
+TEST(GpsdParser, ThreeDFixPopulatesNavSatFix)
+{
+  auto parser = makeParser();
+  gps_data_t data = makeThreeDFix();
+
+  auto fix = parser->parseNavSatFix(data, rclcpp::Time(42, 0));
+
+  ASSERT_TRUE(fix.has_value());
+  EXPECT_EQ(fix->header.frame_id, "gps");
+  EXPECT_EQ(fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_FIX);
+  EXPECT_EQ(fix->status.service, sensor_msgs::msg::NavSatStatus::SERVICE_GPS);
+  EXPECT_DOUBLE_EQ(fix->latitude, 29.44);
+  EXPECT_DOUBLE_EQ(fix->longitude, -98.61);
+  EXPECT_DOUBLE_EQ(fix->altitude, 250.0);
+  EXPECT_DOUBLE_EQ(fix->position_covariance[0], 1.5);
+  EXPECT_DOUBLE_EQ(fix->position_covariance[4], 2.5);
+  EXPECT_DOUBLE_EQ(fix->position_covariance[8], 3.5);
+  EXPECT_EQ(fix->position_covariance_type,
+            sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN);
+}
+
+TEST(GpsdParser, TwoDFixHasNanAltitude)
+{
+  auto parser = makeParser();
+  gps_data_t data = makeThreeDFix();
+  data.fix.mode = MODE_2D;
+
+  gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
+
+  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_FIX);
+  EXPECT_DOUBLE_EQ(fix.latitude, 29.44);
+  EXPECT_TRUE(std::isnan(fix.altitude));
+}
+
+TEST(GpsdParser, NoFixSetsNoFixStatus)
+{
+  auto parser = makeParser();
+  gps_data_t data = makeThreeDFix();
+  data.fix.mode = MODE_NO_FIX;
+
+  gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
+  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_NO_FIX);
+  // Position fields are only filled in when there is a fix.
+  EXPECT_DOUBLE_EQ(fix.latitude, 0.0);
+
+  auto navsat_fix = parser->parseNavSatFix(data, rclcpp::Time(42, 0));
+  ASSERT_TRUE(navsat_fix.has_value());  // variance check is off
+  EXPECT_EQ(navsat_fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX);
+}
+
+TEST(GpsdParser, InvalidVarianceRejectsNavSatFixOnly)
+{
+  auto context = makeContext();
+  context.check_fix_by_variance = true;
+  auto parser = makeParser(context);
+
+  gps_data_t data = makeThreeDFix();
+  data.fix.epx = std::nan("");
+
+  // The NavSatFix is suppressed entirely ...
+  EXPECT_FALSE(parser->parseNavSatFix(data, rclcpp::Time(42, 0)).has_value());
+
+  // ... while the GPSFix is still produced, downgraded to NO_FIX.
+  gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
+  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_NO_FIX);
+}
+
+TEST(GpsdParser, ServiceBitmaskAndSbasStatus)
+{
+  auto parser = makeParser();
+  gps_data_t data = makeThreeDFix();
+  setFixStatus(data, kStatusDgps);
+  data.skyview[1].gnssid = GNSSID_GLO;
+  data.skyview[2].gnssid = GNSSID_SBAS;
+  data.skyview[2].used = true;
+  data.satellites_used = 3;
+
+  auto navsat_fix = parser->parseNavSatFix(data, rclcpp::Time(42, 0));
+  ASSERT_TRUE(navsat_fix.has_value());
+  EXPECT_EQ(navsat_fix->status.service,
+            sensor_msgs::msg::NavSatStatus::SERVICE_GPS |
+            sensor_msgs::msg::NavSatStatus::SERVICE_GLONASS);
+  EXPECT_EQ(navsat_fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_SBAS_FIX);
+
+  gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
+  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_SBAS_FIX);
+}
+
+TEST(GpsdParser, DgpsStatusWithoutSbas)
+{
+  auto parser = makeParser();
+  gps_data_t data = makeThreeDFix();
+  setFixStatus(data, kStatusDgps);
+
+  gps_msgs::msg::GPSFix fix = parser->parseGpsFix(data, rclcpp::Time(42, 0));
+  EXPECT_EQ(fix.status.status, gps_msgs::msg::GPSStatus::STATUS_DGPS_FIX);
+
+  auto navsat_fix = parser->parseNavSatFix(data, rclcpp::Time(42, 0));
+  ASSERT_TRUE(navsat_fix.has_value());
+  EXPECT_EQ(navsat_fix->status.status, sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX);
+}
+
+TEST(GpsdParser, NavSatFixStampUsesGpsTimeWhenEnabled)
+{
+  gps_data_t data = makeThreeDFix();
+
+  auto context = makeContext();
+  context.use_gps_time = true;
+  auto fix = makeParser(context)->parseNavSatFix(data, rclcpp::Time(42, 0));
+  ASSERT_TRUE(fix.has_value());
+  EXPECT_EQ(fix->header.stamp.sec, 1700000000);
+  EXPECT_EQ(fix->header.stamp.nanosec, 500000000u);
+
+  fix = makeParser()->parseNavSatFix(data, rclcpp::Time(42, 7));
+  ASSERT_TRUE(fix.has_value());
+  EXPECT_EQ(fix->header.stamp.sec, 42);
+  EXPECT_EQ(fix->header.stamp.nanosec, 7u);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tools/test_against_gpsd.sh
+++ b/tools/test_against_gpsd.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# test_against_gpsd.sh -- build gpsd_client against multiple gpsd releases
+# and run its unit tests linked against each one.
+#
+# gpsd_client supports gpsd API versions 9 and newer (gpsd >= 3.20); older
+# releases are rejected by a compile-time #error, so they are not tested.
+#
+# For each gpsd release tag this script:
+#   1. builds libgps/libgpsmm from source at that tag (cached),
+#   2. builds gpsd_client against that exact library,
+#   3. runs test_gpsd_parser with that library on LD_LIBRARY_PATH.
+#
+# This is what exercises every parser variant: e.g. gpsd 3.20 (API 9)
+# compiles and tests GpsdParserV9, which is preprocessed away when building
+# against newer headers.
+#
+# Usage (with a ROS 2 environment sourced):
+#   tools/test_against_gpsd.sh              # every release >= 3.20
+#   tools/test_against_gpsd.sh 3.20 3.25    # only these releases
+#
+# Environment overrides:
+#   GPSD_REPO_URL    gpsd git remote (default: https://gitlab.com/gpsd/gpsd.git)
+#   GPSD_TEST_CACHE  cache directory (default: <workspace>/.gpsd_versions)
+#
+# Requirements: git, scons, colcon, a C/C++ toolchain, and network access
+# for the initial gpsd clone. gpsd builds, libgps installs, and per-version
+# colcon build dirs are cached, so reruns only rebuild gpsd_client.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(dirname "${SCRIPT_DIR}")
+# Assumes the standard layout <workspace>/src/<repo>/tools/<this script>.
+WORKSPACE=$(cd "${REPO_DIR}/../.." && pwd)
+CACHE=${GPSD_TEST_CACHE:-${WORKSPACE}/.gpsd_versions}
+GPSD_REPO_URL=${GPSD_REPO_URL:-https://gitlab.com/gpsd/gpsd.git}
+GPSD_SRC=${CACHE}/gpsd
+LOGS=${CACHE}/logs
+MIN_VERSION=3.20
+
+log() { printf '\n=== %s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# True if $1 >= $2 in version order.
+version_ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]; }
+
+command -v git >/dev/null || die "git is required"
+command -v scons >/dev/null || die "scons is required (apt install scons)"
+command -v colcon >/dev/null || die "colcon is required"
+[ -n "${AMENT_PREFIX_PATH:-}" ] || die "source your ROS 2 environment first"
+
+mkdir -p "${CACHE}" "${LOGS}"
+# Keep colcon from crawling the cache when run from the workspace root.
+touch "${CACHE}/COLCON_IGNORE"
+
+# Old gpsd releases (e.g. 3.20) import the 'imp' module, which was removed
+# in Python 3.12; give scons a minimal importlib-based stand-in.
+PYSHIM=${CACHE}/pyshim
+mkdir -p "${PYSHIM}"
+cat > "${PYSHIM}/imp.py" <<'EOF'
+"""Minimal stand-in for the 'imp' module (removed in Python 3.12),
+covering the calls old gpsd SConstructs make."""
+import importlib.machinery
+import importlib.util
+import sys
+
+
+def find_module(name, path=None):
+    spec = importlib.machinery.PathFinder.find_spec(name, path)
+    if spec is None:
+        raise ImportError(name)
+    return (None, spec.origin, ('', '', 5))
+
+
+def load_source(name, pathname, file=None):
+    loader = importlib.machinery.SourceFileLoader(name, pathname)
+    spec = importlib.util.spec_from_loader(name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+EOF
+
+if [ ! -d "${GPSD_SRC}/.git" ]; then
+  log "Cloning gpsd from ${GPSD_REPO_URL}"
+  git clone --quiet --filter=blob:none "${GPSD_REPO_URL}" "${GPSD_SRC}" \
+    || die "failed to clone gpsd"
+else
+  # Pick up new release tags; tolerate being offline on reruns.
+  git -C "${GPSD_SRC}" fetch --quiet --tags 2>/dev/null || true
+fi
+
+if [ $# -gt 0 ]; then
+  VERSIONS="$*"
+else
+  VERSIONS=$(git -C "${GPSD_SRC}" tag --list 'release-*' \
+    | sed 's/^release-//' \
+    | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+    | sort -V \
+    | while read -r v; do version_ge "${v}" "${MIN_VERSION}" && echo "${v}"; done)
+fi
+[ -n "${VERSIONS}" ] || die "no gpsd versions selected"
+
+# Build libgps/libgpsmm only; the daemon, clients, python bindings, and man
+# pages are irrelevant to the parser tests and only add build fragility.
+build_gpsd() {
+  local ver=$1
+  local prefix=${CACHE}/install/${ver}
+  local build_log=${LOGS}/gpsd-${ver}.log
+  if [ -f "${prefix}/include/gps.h" ]; then
+    return 0
+  fi
+  git -C "${GPSD_SRC}" checkout --quiet "release-${ver}" || return 1
+  git -C "${GPSD_SRC}" clean -xdfq
+  (cd "${GPSD_SRC}" &&
+   PYTHONPATH="${PYSHIM}${PYTHONPATH:+:${PYTHONPATH}}" \
+   scons -j"$(nproc)" prefix="${prefix}" shared=True \
+         gpsd=False gpsdclients=False python=False qt=False manbuild=False \
+         install >"${build_log}" 2>&1) || return 1
+}
+
+libgps_dir() {
+  local prefix=$1 d
+  for d in lib lib64 "lib/$(gcc -dumpmachine 2>/dev/null)"; do
+    if [ -e "${prefix}/${d}/libgps.so" ]; then
+      echo "${prefix}/${d}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+api_version() {
+  awk '$2 == "GPSD_API_MAJOR_VERSION" { print $3 }' "$1/include/gps.h"
+}
+
+parser_for_api() {
+  if [ "$1" -le 9 ]; then
+    echo GpsdParserV9
+  else
+    echo GpsdParserV16
+  fi
+}
+
+# Returns 0 on pass; 1 = gpsd build failed, 2 = client build failed,
+# 3 = tests failed.
+build_and_test_client() {
+  local ver=$1
+  local prefix=${CACHE}/install/${ver}
+  local base=${CACHE}/colcon/${ver}
+  local libdir
+  libdir=$(libgps_dir "${prefix}") || return 2
+
+  # libgps_INCLUDE_DIRS/libgps_LIBRARIES are the cache variables that
+  # gpsd_client's CMakeLists otherwise fills via find_path/find_library;
+  # presetting them pins the build to this exact gpsd install.
+  (cd "${WORKSPACE}" &&
+   colcon build --packages-up-to gpsd_client \
+     --build-base "${base}/build" --install-base "${base}/install" \
+     --cmake-args "-Dlibgps_INCLUDE_DIRS=${prefix}/include" \
+                  "-Dlibgps_LIBRARIES=${libdir}/libgps.so" \
+     >"${LOGS}/client-${ver}.log" 2>&1) || return 2
+
+  # Prepend the freshly built libgpsd_client and this version's libgps so
+  # neither can be shadowed by copies from an underlay on LD_LIBRARY_PATH.
+  LD_LIBRARY_PATH="${base}/build/gpsd_client:${libdir}:${LD_LIBRARY_PATH:-}" \
+    "${base}/build/gpsd_client/test_gpsd_parser" \
+    >"${LOGS}/test-${ver}.log" 2>&1 || return 3
+}
+
+RESULTS=""
+FAILED=0
+
+for ver in ${VERSIONS}; do
+  log "gpsd ${ver}: building libgps"
+  if ! build_gpsd "${ver}"; then
+    echo "gpsd ${ver}: libgps build FAILED (see ${LOGS}/gpsd-${ver}.log)"
+    RESULTS="${RESULTS}${ver}|?|?|FAIL(gpsd build)\n"
+    FAILED=1
+    continue
+  fi
+
+  prefix=${CACHE}/install/${ver}
+  api=$(api_version "${prefix}")
+  parser=$(parser_for_api "${api}")
+
+  log "gpsd ${ver} (API ${api}, ${parser}): building gpsd_client and testing"
+  build_and_test_client "${ver}"
+  case $? in
+    0) result="PASS" ;;
+    2) result="FAIL(client build)"; FAILED=1 ;;
+    3) result="FAIL(tests)"; FAILED=1 ;;
+    *) result="FAIL"; FAILED=1 ;;
+  esac
+  echo "gpsd ${ver}: ${result}"
+  [ "${result}" = "PASS" ] || echo "  logs: ${LOGS}/client-${ver}.log ${LOGS}/test-${ver}.log"
+  RESULTS="${RESULTS}${ver}|${api}|${parser}|${result}\n"
+done
+
+log "Summary"
+printf '%-10s %-5s %-15s %s\n' "GPSD" "API" "PARSER" "RESULT"
+printf '%b' "${RESULTS}" | while IFS='|' read -r ver api parser result; do
+  [ -n "${ver}" ] && printf '%-10s %-5s %-15s %s\n' "${ver}" "${api}" "${parser}" "${result}"
+done
+
+exit "${FAILED}"


### PR DESCRIPTION
This re-architects the code to use version specific parsers for different versions of GPSd. This should greatly simplify maintenance and make the code more maintainable by removing the embedded conditional compiles.